### PR TITLE
v1/public/* GET endpoints are allowed without token for local requests

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/WebSecurityConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/WebSecurityConfiguration.java
@@ -223,6 +223,14 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                     || lowercaseHeader.startsWith("wget");
         }
 
+        /**
+         * Returns true if the request comes from localhost and is allowed to be call without authentication.
+         * This is required mainly to enable CLI requests that comes from the same host of Axon Server.
+         *
+         * @param httpServletRequest the request
+         * @return true if the request comes from localhost and is allowed to be call without authentication,
+         * false otherwise
+         */
         private boolean isLocalRequest(HttpServletRequest httpServletRequest) {
             return (
                     (httpServletRequest.getRequestURI().startsWith("/v1/public")


### PR DESCRIPTION
CLI commands now can be performed locally without token.
This PR solves the support ticke #125. 
As it is an isolated change, as discussed in chat, I think is a good idea to release as hotfix in 4.1.3.