### PR TITLE
Allow for multiple grpc messages to be in transit for the same request

### DIFF
--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -150,8 +150,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/axonserver/src/main/java/io/axoniq/axonserver/config/MessagingPlatformConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/MessagingPlatformConfiguration.java
@@ -107,6 +107,14 @@ public class MessagingPlatformConfiguration {
      */
     private String pidFileLocation = ".";
 
+    /**
+     * The initial flow control setting for gRPC level messages. This is the number of messages that may may be en-route
+     * before the sender stops emitting messages. This setting is per-request and only affects streaming requests or
+     * responses. Application-level flow control settings and buffer restriction settings are still in effect.
+     * Defaults to 500.
+     */
+    private int grpcBufferedMessages = 500;
+
     public MessagingPlatformConfiguration(SystemInfoProvider systemInfoProvider) {
         this.systemInfoProvider = systemInfoProvider;
     }
@@ -287,5 +295,13 @@ public class MessagingPlatformConfiguration {
 
     public void setPidFileLocation(String pidFileLocation) {
         this.pidFileLocation = pidFileLocation;
+    }
+
+    public int getGrpcBufferedMessages() {
+        return grpcBufferedMessages;
+    }
+
+    public void setGrpcBufferedMessages(int grpcBufferedMessages) {
+        this.grpcBufferedMessages = grpcBufferedMessages;
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcBufferingInterceptor.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcBufferingInterceptor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+package io.axoniq.axonserver.grpc;
+
+import io.grpc.*;
+
+import javax.annotation.Nullable;
+
+public class GrpcBufferingInterceptor implements ClientInterceptor, ServerInterceptor {
+    private final int additionalBuffer;
+
+    public GrpcBufferingInterceptor(int additionalBuffer) {this.additionalBuffer = additionalBuffer;}
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        ClientCall<ReqT, RespT> call = next.newCall(method, callOptions);
+        if (additionalBuffer <= 0 || method.getType().serverSendsOneMessage()) {
+            return call;
+        }
+        return new AdditionalMessageRequestingCall<>(call, additionalBuffer);
+
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        ServerCall.Listener<ReqT> listener = next.startCall(call, headers);
+        if (additionalBuffer > 0 && !call.getMethodDescriptor().getType().clientSendsOneMessage()) {
+            call.request(additionalBuffer);
+        }
+        return listener;
+    }
+
+    private static class AdditionalMessageRequestingCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
+        private final ClientCall<ReqT, RespT> call;
+        private final int additionalBuffer;
+
+        public AdditionalMessageRequestingCall(ClientCall<ReqT, RespT> call,
+                                               int additionalBuffer) {this.call = call;
+            this.additionalBuffer = additionalBuffer;
+        }
+
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+            call.start(responseListener, headers);
+            call.request(additionalBuffer);
+        }
+
+        @Override
+        public void request(int numMessages) {
+            call.request(numMessages);
+        }
+
+        @Override
+        public void cancel(@Nullable String message, @Nullable Throwable cause) {
+            call.cancel(message, cause);
+        }
+
+        @Override
+        public void halfClose() {
+            call.halfClose();
+        }
+
+        @Override
+        public void sendMessage(ReqT message) {
+            call.sendMessage(message);
+        }
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/GatewayTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/GatewayTest.java
@@ -122,7 +122,7 @@ public class GatewayTest {
         accessController = new AxonServerAccessController() {
             @Override
             public boolean allowed(String fullMethodName, String context, String token) {
-                return "1234".equals(token);
+                return "1234".equals(token) && context == "Test";
             }
 
             @Override
@@ -162,6 +162,7 @@ public class GatewayTest {
         try {
             PlatformServiceGrpc.newBlockingStub(channel)
                                .withInterceptors(getClientInterceptor(GrpcMetadataKeys.TOKEN_KEY, "2345"))
+                               .withInterceptors(getClientInterceptor(GrpcMetadataKeys.CONTEXT_MD_KEY, "Test"))
                                .getPlatformServer(ClientIdentification.newBuilder().build());
             fail("Expected exception");
         } catch (StatusRuntimeException sre) {

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/GatewayTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/GatewayTest.java
@@ -122,7 +122,7 @@ public class GatewayTest {
         accessController = new AxonServerAccessController() {
             @Override
             public boolean allowed(String fullMethodName, String context, String token) {
-                return "1234".equals(token) && context == "Test";
+                return "1234".equals(token) && Topology.DEFAULT_CONTEXT.equals(context);
             }
 
             @Override
@@ -162,7 +162,7 @@ public class GatewayTest {
         try {
             PlatformServiceGrpc.newBlockingStub(channel)
                                .withInterceptors(getClientInterceptor(GrpcMetadataKeys.TOKEN_KEY, "2345"))
-                               .withInterceptors(getClientInterceptor(GrpcMetadataKeys.CONTEXT_MD_KEY, "Test"))
+                               .withInterceptors(getClientInterceptor(GrpcMetadataKeys.CONTEXT_MD_KEY, Topology.DEFAULT_CONTEXT))
                                .getPlatformServer(ClientIdentification.newBuilder().build());
             fail("Expected exception");
         } catch (StatusRuntimeException sre) {
@@ -173,6 +173,8 @@ public class GatewayTest {
         PlatformInfo result = PlatformServiceGrpc.newBlockingStub(channel)
                                                  .withInterceptors(getClientInterceptor(GrpcMetadataKeys.TOKEN_KEY,
                                                                                         "1234"))
+                                                 .withInterceptors(getClientInterceptor(GrpcMetadataKeys.CONTEXT_MD_KEY,
+                                                                                        Topology.DEFAULT_CONTEXT))
                                                  .getPlatformServer(ClientIdentification.newBuilder().build());
         assertEquals(Topology.DEFAULT_CONTEXT, result.getPrimary().getNodeName());
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/GrpcBufferingInterceptorTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/GrpcBufferingInterceptorTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.grpc;
+
+import io.grpc.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.io.InputStream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+public class GrpcBufferingInterceptorTest {
+
+    private CallOptions mockCallOptions;
+    private Channel mockChannel;
+    private ClientCall.Listener<Object> mockResponseListener;
+    private ClientCall<Object, Object> mockCall;
+    private ServerCall<Object, Object> mockServerCall;
+    private Metadata mockMetaData;
+    private ServerCallHandler<Object, Object> mockServerCallHandler;
+    private ServerCall.Listener<Object> mockListener;
+
+    @Before
+    public void setUp() throws Exception {
+        mockServerCall = mock(ServerCall.class);
+        mockMetaData = InternalMetadata.newMetadata();
+        mockCallOptions = CallOptions.DEFAULT;
+        mockChannel = mock(Channel.class);
+        mockResponseListener = mock(ClientCall.Listener.class);
+        mockCall = mock(ClientCall.class);
+        mockServerCallHandler = mock(ServerCallHandler.class);
+        mockListener = mock(ServerCall.Listener.class);
+        when(mockChannel.newCall(any(), any())).thenReturn(mockCall);
+        when(mockServerCallHandler.startCall(any(), any())).thenReturn(mockListener);
+
+    }
+
+    @Test
+    public void testInterceptClientCall_BiDiStreaming() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.BIDI_STREAMING);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
+        ClientCall<Object, Object> actual = testSubject.interceptCall(method, mockCallOptions, mockChannel);
+
+        verify(mockChannel).newCall(method, mockCallOptions);
+
+        actual.start(mockResponseListener, null);
+
+        verify(mockCall).request(1000);
+    }
+
+    @Test
+    public void testInterceptClientCall_ServerStreaming() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.SERVER_STREAMING);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
+        ClientCall<Object, Object> actual = testSubject.interceptCall(method, mockCallOptions, mockChannel);
+
+        verify(mockChannel).newCall(method, mockCallOptions);
+
+        actual.start(mockResponseListener, null);
+
+        verify(mockCall).request(1000);
+    }
+
+    @Test
+    public void testInterceptClientCall_ClientStreaming() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.CLIENT_STREAMING);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
+        ClientCall<Object, Object> actual = testSubject.interceptCall(method, mockCallOptions, mockChannel);
+
+        verify(mockChannel).newCall(method, mockCallOptions);
+
+        actual.start(mockResponseListener, null);
+
+        verify(mockCall, never()).request(anyInt());
+    }
+
+    @Test
+    public void testInterceptClientCall_NoStreaming() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.UNARY);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
+        ClientCall<Object, Object> actual = testSubject.interceptCall(method, mockCallOptions, mockChannel);
+
+        verify(mockChannel).newCall(method, mockCallOptions);
+
+        actual.start(mockResponseListener, null);
+
+        verify(mockCall, never()).request(anyInt());
+    }
+
+    @Test
+    public void testInterceptClientCall_ZeroBuffer() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.BIDI_STREAMING);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(0);
+        ClientCall<Object, Object> actual = testSubject.interceptCall(method, mockCallOptions, mockChannel);
+
+        verify(mockChannel).newCall(method, mockCallOptions);
+
+        actual.start(mockResponseListener, null);
+
+        verify(mockCall, never()).request(anyInt());
+    }
+
+    @Test
+    public void testInterceptServerCall_BiDiStreaming() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.BIDI_STREAMING);
+        when(mockServerCall.getMethodDescriptor()).thenReturn(method);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
+        testSubject.interceptCall(mockServerCall, mockMetaData, mockServerCallHandler);
+
+        InOrder inOrder = inOrder(mockServerCallHandler, mockServerCall);
+        inOrder.verify(mockServerCallHandler).startCall(mockServerCall, mockMetaData);
+        inOrder.verify(mockServerCall).request(1000);
+    }
+
+    @Test
+    public void testInterceptServerCall_ClientStreaming() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.CLIENT_STREAMING);
+        when(mockServerCall.getMethodDescriptor()).thenReturn(method);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
+        testSubject.interceptCall(mockServerCall, mockMetaData, mockServerCallHandler);
+
+        InOrder inOrder = inOrder(mockServerCallHandler, mockServerCall);
+        inOrder.verify(mockServerCallHandler).startCall(mockServerCall, mockMetaData);
+        inOrder.verify(mockServerCall).request(1000);
+    }
+
+    @Test
+    public void testInterceptServerCall_ServerStreaming() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.SERVER_STREAMING);
+        when(mockServerCall.getMethodDescriptor()).thenReturn(method);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
+        testSubject.interceptCall(mockServerCall, mockMetaData, mockServerCallHandler);
+
+        verify(mockServerCallHandler).startCall(mockServerCall, mockMetaData);
+        verify(mockServerCall, never()).request(anyInt());
+    }
+
+    @Test
+    public void testInterceptServerCall_NoStreaming() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.UNARY);
+        when(mockServerCall.getMethodDescriptor()).thenReturn(method);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
+        testSubject.interceptCall(mockServerCall, mockMetaData, mockServerCallHandler);
+
+        verify(mockServerCallHandler).startCall(mockServerCall, mockMetaData);
+        verify(mockServerCall, never()).request(anyInt());
+    }
+
+    @Test
+    public void testInterceptServerCall_ZeroBuffer() {
+        MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.BIDI_STREAMING);
+        when(mockServerCall.getMethodDescriptor()).thenReturn(method);
+
+        GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(0);
+        testSubject.interceptCall(mockServerCall, mockMetaData, mockServerCallHandler);
+
+        verify(mockServerCallHandler).startCall(mockServerCall, mockMetaData);
+        verify(mockServerCall, never()).request(anyInt());
+    }
+
+    private MethodDescriptor<Object, Object> buildMethod(MethodDescriptor.MethodType type) {
+        return MethodDescriptor.newBuilder()
+                               .setFullMethodName("test")
+                               .setType(type)
+                               .setRequestMarshaller(new StubMarshaller())
+                               .setResponseMarshaller(new StubMarshaller())
+                               .build();
+    }
+
+    private static class StubMarshaller implements MethodDescriptor.Marshaller<Object> {
+        @Override
+        public InputStream stream(Object value) {
+            return null;
+        }
+
+        @Override
+        public Object parse(InputStream stream) {
+            return null;
+        }
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandDispatcherTest.java
@@ -22,12 +22,13 @@ import io.axoniq.axonserver.metric.DefaultMetricCollector;
 import io.axoniq.axonserver.topology.Topology;
 import io.axoniq.axonserver.util.CountingStreamObserver;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.*;
-import org.junit.runner.*;
-import org.mockito.*;
-import org.mockito.runners.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -58,12 +59,10 @@ public class CommandDispatcherTest {
                 Sets.newHashSet(new CommandRegistrationCache.RegistrationEntry(Topology.DEFAULT_CONTEXT, "Command"));
         dummyRegistrations.put(new DirectCommandHandler(new CountingStreamObserver<>(), new ClientIdentification(Topology.DEFAULT_CONTEXT, "client"),"component"),
                 commands);
-        when( registrations.getAll()).thenReturn(dummyRegistrations);
     }
 
     @Test
     public void unregisterCommandHandler()  {
-        when(registrations.getCommandsFor(anyObject())).thenReturn(Collections.singleton("One"));
         commandDispatcher.on(new TopologyEvents.ApplicationDisconnected(null, null, "client"));
     }
 
@@ -158,8 +157,6 @@ public class CommandDispatcherTest {
                 .setName("Command")
                 .setMessageIdentifier("12")
                 .build();
-        ClientIdentification clientIdentification = new ClientIdentification(Topology.DEFAULT_CONTEXT,"1234");
-        when(registrations.findByClientAndCommand(eq(clientIdentification), anyObject())).thenReturn(null);
 
         commandDispatcher.dispatch(Topology.DEFAULT_CONTEXT, new SerializedCommand(request), responseObserver::onNext, true);
         assertEquals(1, responseObserver.count);

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/QueryDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/QueryDispatcherTest.java
@@ -162,8 +162,6 @@ public class QueryDispatcherTest {
 
         AtomicInteger callbackCount = new AtomicInteger(0);
 
-        when(registrationCache.find(anyObject(), anyObject())).thenReturn(null);
-
         SerializedQuery forwardedQuery = new SerializedQuery(Topology.DEFAULT_CONTEXT, "client", request);
         queryDispatcher.dispatchProxied(forwardedQuery, r -> callbackCount.incrementAndGet(), s->{});
         assertEquals(1, callbackCount.get());


### PR DESCRIPTION
The default gRPC behavior is to allow only one message in transit on
a streaming request or response. While this is per call, this may
severely limit throughput on streams.

This commit increases the number of messages that may be in transit
on a stream, and defaults to 500. Other flow control mechanisms are
unaffected.