### PR TITLE
Subscription query memory leak

### DIFF
--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -192,6 +192,28 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-server-connector</artifactId>
+            <version>4.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>4.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 
@@ -229,10 +251,35 @@
         </extensions>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>2.0.2.RELEASE</version>
                 <executions>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-integration-test</id>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
                     <execution>
                         <goals>
                             <goal>repackage</goal>

--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -262,6 +262,9 @@
                         <goals>
                             <goal>start</goal>
                         </goals>
+                        <configuration>
+                            <wait>45000</wait>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>post-integration-test</id>

--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -194,19 +194,8 @@
         </dependency>
         <dependency>
             <groupId>org.axonframework</groupId>
-            <artifactId>axon-server-connector</artifactId>
-            <version>4.1.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.axonframework</groupId>
             <artifactId>axon-spring-boot-starter</artifactId>
             <version>4.1.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/SubscriptionQueryRequestTarget.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/SubscriptionQueryRequestTarget.java
@@ -106,6 +106,7 @@ public class SubscriptionQueryRequestTarget extends ReceivingStreamObserver<Subs
         if (!subscriptionQuery.isEmpty()) {
             unsubscribe(subscriptionQuery.get(0));
         }
+        responseObserver.onError(t);
     }
 
     @Override
@@ -113,6 +114,7 @@ public class SubscriptionQueryRequestTarget extends ReceivingStreamObserver<Subs
         if (!subscriptionQuery.isEmpty()) {
             unsubscribe(subscriptionQuery.get(0));
         }
+        responseObserver.onCompleted();
     }
 
     private void unsubscribe(SubscriptionQuery cancel) {

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/SubscriptionQueryITCase.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/SubscriptionQueryITCase.java
@@ -81,7 +81,7 @@ public class SubscriptionQueryITCase {
     }
 
     private boolean checkObjectGarbageCollected(Reference<Object> ref, ReferenceQueue<Object> referenceQueue) {
-        Reference<? extends Object> polledRef = referenceQueue.poll();
+        Reference<?> polledRef = referenceQueue.poll();
         return polledRef == ref;
     }
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/SubscriptionQueryITCase.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/SubscriptionQueryITCase.java
@@ -62,7 +62,7 @@ public class SubscriptionQueryITCase {
         connectionManager.shutdown();
     }
 
-    public SubscriptionQueryResult invokeQuery() {
+    private SubscriptionQueryResult invokeQuery() {
         GenericSubscriptionQueryMessage<String, String, String> query =
                 new GenericSubscriptionQueryMessage<>("hi",
                                                       "test",

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/SubscriptionQueryITCase.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/SubscriptionQueryITCase.java
@@ -1,0 +1,87 @@
+package io.axoniq.axonserver.grpc;
+
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
+import org.axonframework.axonserver.connector.query.QueryPriorityCalculator;
+import org.axonframework.common.Registration;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.GenericSubscriptionQueryMessage;
+import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryResponseMessage;
+import org.axonframework.queryhandling.SimpleQueryBus;
+import org.axonframework.queryhandling.SubscriptionQueryResult;
+import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.*;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration test for Subscription Queries
+ *
+ * @author Sara Pellegrini
+ * @since 4.2
+ */
+
+public class SubscriptionQueryITCase {
+
+    private final AxonServerConfiguration configuration = AxonServerConfiguration.builder().build();
+
+    private final AxonServerConnectionManager connectionManager = new AxonServerConnectionManager(configuration);
+
+    private final SimpleQueryBus queryBus = SimpleQueryBus.builder().build();
+
+    private final QueryBus axonServerQueryBus = new AxonServerQueryBus(connectionManager,
+                                                                       configuration,
+                                                                       queryBus.queryUpdateEmitter(),
+                                                                       queryBus,
+                                                                       XStreamSerializer.defaultSerializer(),
+                                                                       XStreamSerializer.defaultSerializer(),
+                                                                       QueryPriorityCalculator
+                                                                               .defaultQueryPriorityCalculator());
+
+    @Test
+    public void testMemoryLeak() throws InterruptedException {
+        Registration echo = axonServerQueryBus.subscribe("test", String.class, Message::getPayload);
+        ReferenceQueue<Object> referenceQueue = new ReferenceQueue<>();
+        Reference<Object> ref = new PhantomReference<>(invokeQuery(), referenceQueue);
+        queryBus.queryUpdateEmitter().emit(String.class, c -> true, "update");
+        assertFalse(checkObjectGarbageCollected(ref, referenceQueue));
+        queryBus.queryUpdateEmitter().complete(String.class, c -> true);
+        System.gc();
+        Thread.sleep(1000);
+        System.gc();
+        assertTrue(checkObjectGarbageCollected(ref, referenceQueue));
+        echo.cancel();
+        connectionManager.shutdown();
+    }
+
+    public SubscriptionQueryResult invokeQuery() {
+        GenericSubscriptionQueryMessage<String, String, String> query =
+                new GenericSubscriptionQueryMessage<>("hi",
+                                                      "test",
+                                                      ResponseTypes.instanceOf(String.class),
+                                                      ResponseTypes.instanceOf(String.class));
+        SubscriptionQueryResult<QueryResponseMessage<String>, SubscriptionQueryUpdateMessage<String>> result = queryBus
+                .subscriptionQuery(query);
+
+        result.updates()
+              .subscribe(
+                      System.out::println,
+                      System.out::println,
+                      () -> System.out.println("completed"));
+
+        return result;
+    }
+
+    private boolean checkObjectGarbageCollected(Reference<Object> ref, ReferenceQueue<Object> referenceQueue) {
+        Reference<? extends Object> polledRef = referenceQueue.poll();
+        return polledRef == ref;
+    }
+}


### PR DESCRIPTION
The bidirectional stream call is now properly closed.
The integration test verifies that the SubscriptionQueryResult is garbage collected after the query is completed by the emitter.