### PR TITLE
Option to forcefully reserve sequence numbers

### DIFF
--- a/axonserver/README.txt
+++ b/axonserver/README.txt
@@ -3,17 +3,18 @@ This is the Axon Server Standard Edition, version 4.1.5
 For information about the Axon Framework and Axon Server,
 visit https://docs.axoniq.io.
 
+Release Notes for version 4.1.6
+-------------------------------
+
+* Added operation to set cached version numbers for aggregates
+
 Release Notes for version 4.1.5
 -------------------------------
 
 * Fix for authorization path mapping and improvements for rest access control
-
 * Improvements in release procedure for docker images
-
 * Fix for subscription query memory leak
-
 * Improvements in error reporting in case of disconnected applications
-
 * Improvements in detection of insufficient disk space
 
 Release Notes for version 4.1.4

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
@@ -88,8 +88,9 @@ public interface EventStorageEngine {
     /**
      * Reserve the sequence numbers of the aggregates in the provided list to avoid collisions during store.
      * @param events list of events to store
+     * @param force force the specified sequence numbers to be correct
      */
-    default void reserveSequenceNumbers(List<SerializedEvent> events) {
+    default void reserveSequenceNumbers(List<SerializedEvent> events, boolean force) {
     }
 
     /**

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/CleanUtils.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/CleanUtils.java
@@ -99,7 +99,7 @@ public class CleanUtils {
         try {
             cleanMethod.invoke(cleanerMethod.invoke(buf));
             logger.debug("Memory mapped buffer cleared for {}", file);
-        } catch (IllegalArgumentException | InvocationTargetException | SecurityException | IllegalAccessException exception) {
+        } catch (Throwable exception) {
             logger.warn("Clean failed", exception);
         }
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/IndexManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/IndexManager.java
@@ -49,10 +49,11 @@ public class IndexManager {
         this.context = context;
     }
 
-    public void createIndex(Long segment, Map<String, SortedSet<PositionInfo>> positionsPerAggregate, boolean force) {
+    public void createIndex(Long segment, Map<String, SortedSet<PositionInfo>> positionsPerAggregate) {
         File tempFile = storageProperties.indexTemp(context, segment);
-        if (tempFile.exists() && (!force || !FileUtils.delete(tempFile))) {
-            return;
+        if (tempFile.exists() || !FileUtils.delete(tempFile)) {
+            throw new MessagingPlatformException(ErrorCode.INDEX_WRITE_ERROR,
+                                                 "Failed to delete temp index file:" + tempFile);
         }
         DBMaker.Maker maker = DBMaker.fileDB(tempFile);
         if (storageProperties.isUseMmapIndex()) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/InputStreamEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/InputStreamEventStore.java
@@ -91,7 +91,7 @@ public class InputStreamEventStore extends SegmentBasedEventStore {
                                                             event.getEvent().getAggregateSequenceNumber()));
                 }
             }
-            indexManager.createIndex(segment, aggregatePositions, true);
+            indexManager.createIndex(segment, aggregatePositions);
         }
 
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
@@ -361,18 +361,15 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
     }
 
     private void completeSegment(WritePosition writePosition) {
-        try {
-            indexManager.createIndex(writePosition.segment, positionsPerSegmentMap.get(writePosition.segment), false);
-        } catch( RuntimeException re) {
-            logger.error("Failed to create index", re);
-            throw new MessagingPlatformException(ErrorCode.INDEX_WRITE_ERROR, re.getMessage(), re);
-        }
-        if( next != null) {
+        indexManager.createIndex(writePosition.segment, positionsPerSegmentMap.get(writePosition.segment));
+        if (next != null) {
             next.handover(writePosition.segment, () -> {
                 positionsPerSegmentMap.remove(writePosition.segment);
                 sequenceNumbersPerAggregate.clear();
                 ByteBufferEventSource source = readBuffers.remove(writePosition.segment);
-                logger.debug("Handed over {}, remaining segments: {}", writePosition.segment, positionsPerSegmentMap.keySet());
+                logger.debug("Handed over {}, remaining segments: {}",
+                             writePosition.segment,
+                             positionsPerSegmentMap.keySet());
                 source.clean(storageProperties.getPrimaryCleanupDelay());
             });
         }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/Synchronizer.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/Synchronizer.java
@@ -85,7 +85,11 @@ public class Synchronizer {
         try {
             WritePosition toSync = syncAndCloseFile.pollFirst();
             if (toSync != null) {
-                closeFile(toSync);
+                try {
+                    closeFile(toSync);
+                } catch (Exception ex) {
+                    syncAndCloseFile.add(toSync);
+                }
             }
         } catch( RuntimeException t) {
             log.warn("syncAndClose job failed - {}", t.getMessage(), t);

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/SingleInstanceTransactionManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/SingleInstanceTransactionManager.java
@@ -33,6 +33,6 @@ public class SingleInstanceTransactionManager implements StorageTransactionManag
 
     @Override
     public void reserveSequenceNumbers(List<SerializedEvent> eventList) {
-        eventStorageEngine.reserveSequenceNumbers(eventList);
+        eventStorageEngine.reserveSequenceNumbers(eventList, false);
     }
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/IndexManagerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/IndexManagerTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.SortedSet;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -52,7 +51,7 @@ public class IndexManagerTest {
         positions.add(positionInfo);
         Map<String, SortedSet<PositionInfo>> positionsPerAggregate = Collections.singletonMap(aggregateId,
                                                                                               positions);
-        indexManager.createIndex(segment, positionsPerAggregate, true);
+        indexManager.createIndex(segment, positionsPerAggregate);
 
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         int concurrentRequests = 100;


### PR DESCRIPTION
Reserve sequence numbers without checking (used in enterprise edition).

If creation of index should fail for any reason, do not complete the segment yet.