### PR TITLE
Bug fix for unexpected aggregate sequence exception.

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
@@ -89,8 +89,11 @@ public interface EventStorageEngine {
      * Reserve the sequence numbers of the aggregates in the provided list to avoid collisions during store.
      * @param events list of events to store
      * @param force force the specified sequence numbers to be correct
+     *                   * @return a function to unreserve the sequence numbers
      */
-    default void reserveSequenceNumbers(List<SerializedEvent> events, boolean force) {
+    default Runnable reserveSequenceNumbers(List<SerializedEvent> events, boolean force) {
+        return () -> {
+        };
     }
 
     /**

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/SingleInstanceTransactionManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/SingleInstanceTransactionManager.java
@@ -32,7 +32,7 @@ public class SingleInstanceTransactionManager implements StorageTransactionManag
     }
 
     @Override
-    public void reserveSequenceNumbers(List<SerializedEvent> eventList) {
-        eventStorageEngine.reserveSequenceNumbers(eventList, false);
+    public Runnable reserveSequenceNumbers(List<SerializedEvent> eventList) {
+        return eventStorageEngine.reserveSequenceNumbers(eventList, false);
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/StorageTransactionManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/StorageTransactionManager.java
@@ -22,7 +22,7 @@ public interface StorageTransactionManager {
 
     CompletableFuture<Long> store(List<SerializedEvent> eventList);
 
-    void reserveSequenceNumbers(List<SerializedEvent> eventList);
+    Runnable reserveSequenceNumbers(List<SerializedEvent> eventList);
 
     default long waitingTransactions() {
         return 0;

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStorageEngineTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStorageEngineTest.java
@@ -62,8 +62,9 @@ public class LocalEventStorageEngineTest {
                     }
 
                     @Override
-                    public void reserveSequenceNumbers(List<SerializedEvent> eventList) {
-
+                    public Runnable reserveSequenceNumbers(List<SerializedEvent> eventList) {
+                        return () -> {
+                        };
                     }
 
                     @Override


### PR DESCRIPTION
This is a hotfix for the support ticket related to unexpected aggregate sequence exception.
The problem was that the sequenceNumbersPerAggregate map in PrimaryEventStore sometime is not clean when a node is elected Leader.
The reason was that it was possible to reserve sequences just after the clean up triggered by leader step down was performed.