### PR TITLE
Subscription query update emitter reconnect fails

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcher.java
@@ -110,6 +110,6 @@ public class SubscriptionQueryDispatcher {
 
     @EventListener
     public void on(TopologyEvents.ApplicationDisconnected event){
-        subscriptionsSent.remove(event.getClient());
+        subscriptionsSent.remove(new ClientIdentification(event.getContext(), event.getClient()));
     }
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcherTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.message.query.subscription;
+
+import io.axoniq.axonserver.applicationevents.SubscriptionEvents;
+import io.axoniq.axonserver.applicationevents.TopologyEvents;
+import io.axoniq.axonserver.grpc.query.QueryProviderInbound;
+import io.axoniq.axonserver.grpc.query.QueryRequest;
+import io.axoniq.axonserver.grpc.query.QuerySubscription;
+import io.axoniq.axonserver.grpc.query.SubscriptionQuery;
+import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
+import io.axoniq.axonserver.message.ClientIdentification;
+import io.axoniq.axonserver.message.query.QueryHandler;
+import io.axoniq.axonserver.message.query.QueryRegistrationCache;
+import io.axoniq.axonserver.util.CountingStreamObserver;
+import org.junit.*;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Marc Gathier
+ * @since 4.1
+ */
+public class SubscriptionQueryDispatcherTest {
+
+    private SubscriptionQueryDispatcher testSubject = new SubscriptionQueryDispatcher(() -> getDirectSubscriptions(),
+                                                                                      new QueryRegistrationCache(
+                                                                                              (queryDefinition, componentName, queryHandlers) -> null));
+
+    private Iterator<DirectSubscriptionQueries.ContextSubscriptionQuery> getDirectSubscriptions() {
+        List<DirectSubscriptionQueries.ContextSubscriptionQuery> subscriptionQueries = new ArrayList<>();
+        subscriptionQueries.add(new DirectSubscriptionQueries.ContextSubscriptionQuery("Demo",
+                                                                                       SubscriptionQuery.newBuilder()
+                                                                                                        .setSubscriptionIdentifier(
+                                                                                                                "111")
+                                                                                                        .setQueryRequest(
+                                                                                                                QueryRequest
+                                                                                                                        .newBuilder()
+                                                                                                                        .setQuery(
+                                                                                                                                "test")
+                                                                                                                        .build()
+                                                                                                        )
+                                                                                                        .build()));
+        return subscriptionQueries.iterator();
+    }
+
+    @Test
+    public void onApplicationDisconnect() {
+        AtomicInteger dispatchedSubscriptions = new AtomicInteger();
+        SubscriptionEvents.SubscribeQuery subscribeQuery =
+                new SubscriptionEvents.SubscribeQuery("Demo",
+                                                      QuerySubscription.newBuilder().setClientId("client")
+                                                                       .setQuery("test").build(),
+                                                      new QueryHandler<QueryProviderInbound>(
+                                                              new CountingStreamObserver<>(),
+                                                              new ClientIdentification("Demo", "client"),
+                                                              "component") {
+                                                          @Override
+                                                          public void dispatch(SubscriptionQueryRequest query) {
+                                                              dispatchedSubscriptions.incrementAndGet();
+                                                          }
+                                                      });
+        testSubject.on(subscribeQuery);
+        assertEquals(1, dispatchedSubscriptions.get());
+        testSubject.on(new TopologyEvents.ApplicationDisconnected("Demo", "component", "client"));
+        testSubject.on(subscribeQuery);
+        assertEquals(2, dispatchedSubscriptions.get());
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcherTest.java
@@ -35,24 +35,20 @@ import static org.junit.Assert.*;
  */
 public class SubscriptionQueryDispatcherTest {
 
-    private SubscriptionQueryDispatcher testSubject = new SubscriptionQueryDispatcher(() -> getDirectSubscriptions(),
-                                                                                      new QueryRegistrationCache(
-                                                                                              (queryDefinition, componentName, queryHandlers) -> null));
+    private SubscriptionQueryDispatcher testSubject = new SubscriptionQueryDispatcher(
+            this::getDirectSubscriptions,
+            new QueryRegistrationCache((queryDefinition, componentName, queryHandlers) -> null));
 
     private Iterator<DirectSubscriptionQueries.ContextSubscriptionQuery> getDirectSubscriptions() {
         List<DirectSubscriptionQueries.ContextSubscriptionQuery> subscriptionQueries = new ArrayList<>();
-        subscriptionQueries.add(new DirectSubscriptionQueries.ContextSubscriptionQuery("Demo",
-                                                                                       SubscriptionQuery.newBuilder()
-                                                                                                        .setSubscriptionIdentifier(
-                                                                                                                "111")
-                                                                                                        .setQueryRequest(
-                                                                                                                QueryRequest
-                                                                                                                        .newBuilder()
-                                                                                                                        .setQuery(
-                                                                                                                                "test")
-                                                                                                                        .build()
-                                                                                                        )
-                                                                                                        .build()));
+        subscriptionQueries.add(new DirectSubscriptionQueries.ContextSubscriptionQuery(
+                "Demo",
+                SubscriptionQuery.newBuilder()
+                                 .setSubscriptionIdentifier("111")
+                                 .setQueryRequest(QueryRequest.newBuilder()
+                                                              .setQuery("test")
+                                                              .build())
+                                 .build()));
         return subscriptionQueries.iterator();
     }
 


### PR DESCRIPTION
Map of subscriptions sent was not properly updated on disconnected applications, causing the subscriptions not to be send again if same application reconnects.