### PR TITLE
Reduce stacktraces and warnings in log file.

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/exception/ConcurrencyExceptions.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/exception/ConcurrencyExceptions.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 /**
+ * Utility class to easily retrieve the real exception in case of an exception thrown in a concurrent call.
  * @author Marc Gathier
  * @since 4.2.2
  */

--- a/axonserver/src/main/java/io/axoniq/axonserver/exception/ConcurrencyExceptions.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/exception/ConcurrencyExceptions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.exception;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author Marc Gathier
+ * @since 4.2.2
+ */
+public class ConcurrencyExceptions {
+
+    private ConcurrencyExceptions() {
+    }
+
+    /**
+     * Returns the real cause from an exception as thrown by a completable future.
+     *
+     * @param t throwable to unwrap
+     * @return unwrapped throwable
+     */
+    public static Throwable unwrap(Throwable t) {
+        if (t instanceof ExecutionException || t instanceof CompletionException) {
+            return unwrap(t.getCause());
+        }
+        return t;
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/exception/ExceptionUtils.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/exception/ExceptionUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.exception;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+/**
+ * Utilities for exception classes
+ *
+ * @author Marc Gathier
+ * @since 4.2.2
+ */
+public class ExceptionUtils {
+
+    /**
+     * Checks if the given exception is a gRPC CANCELLED exception. This exception occurs when the client cancels the
+     * connection
+     * (usually on a non-clean exit)
+     *
+     * @param cause the exception to analyse
+     * @return true if the exception is that the connections is cancelled
+     */
+    public static boolean isCancelled(Throwable cause) {
+        return (cause instanceof StatusRuntimeException
+                && ((StatusRuntimeException) cause).getStatus().getCode().equals(Status.Code.CANCELLED));
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/CommandService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/CommandService.java
@@ -11,6 +11,7 @@ package io.axoniq.axonserver.grpc;
 
 import io.axoniq.axonserver.applicationevents.SubscriptionEvents;
 import io.axoniq.axonserver.applicationevents.TopologyEvents.CommandHandlerDisconnected;
+import io.axoniq.axonserver.exception.ExceptionUtils;
 import io.axoniq.axonserver.grpc.command.Command;
 import io.axoniq.axonserver.grpc.command.CommandProviderOutbound;
 import io.axoniq.axonserver.grpc.command.CommandServiceGrpc;
@@ -168,7 +169,7 @@ public class CommandService implements AxonServerClientService {
 
             @Override
             public void onError(Throwable cause) {
-                if (!GrpcExceptionBuilder.isCancelled(cause)) {
+                if (!ExceptionUtils.isCancelled(cause)) {
                     logger.warn("{}: Error on connection from subscriber - {}", clientRef, cause.getMessage());
                 }
                 cleanup();

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/CommandService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/CommandService.java
@@ -168,7 +168,9 @@ public class CommandService implements AxonServerClientService {
 
             @Override
             public void onError(Throwable cause) {
-                logger.warn("{}: Error on connection from subscriber - {}", clientRef, cause.getMessage());
+                if (!GrpcExceptionBuilder.isCancelled(cause)) {
+                    logger.warn("{}: Error on connection from subscriber - {}", clientRef, cause.getMessage());
+                }
                 cleanup();
             }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcExceptionBuilder.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcExceptionBuilder.java
@@ -12,6 +12,7 @@ package io.axoniq.axonserver.grpc;
 import io.axoniq.axonserver.exception.ErrorCode;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
 import io.grpc.Metadata;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,5 +69,11 @@ public class GrpcExceptionBuilder {
             return description.substring(stdPrefix.length());
         }
         return createMessage(throwable);
+    }
+
+    public static boolean isCancelled(Throwable cause) {
+        return (cause instanceof StatusRuntimeException && ((StatusRuntimeException) cause).getStatus().getCode()
+                                                                                           .equals(
+                                                                                                   Status.Code.CANCELLED));
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcExceptionBuilder.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcExceptionBuilder.java
@@ -71,6 +71,14 @@ public class GrpcExceptionBuilder {
         return createMessage(throwable);
     }
 
+    /**
+     * Checks if the given exception is a gRPC CANCELLED exception. This exception occurs when the client cancels the
+     * connection
+     * (usually on a non-clean exit)
+     *
+     * @param cause the exception to analyse
+     * @return true if the exception is that the connections is cancelled
+     */
     public static boolean isCancelled(Throwable cause) {
         return (cause instanceof StatusRuntimeException && ((StatusRuntimeException) cause).getStatus().getCode()
                                                                                            .equals(

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcExceptionBuilder.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcExceptionBuilder.java
@@ -70,18 +70,4 @@ public class GrpcExceptionBuilder {
         }
         return createMessage(throwable);
     }
-
-    /**
-     * Checks if the given exception is a gRPC CANCELLED exception. This exception occurs when the client cancels the
-     * connection
-     * (usually on a non-clean exit)
-     *
-     * @param cause the exception to analyse
-     * @return true if the exception is that the connections is cancelled
-     */
-    public static boolean isCancelled(Throwable cause) {
-        return (cause instanceof StatusRuntimeException && ((StatusRuntimeException) cause).getStatus().getCode()
-                                                                                           .equals(
-                                                                                                   Status.Code.CANCELLED));
-    }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/QueryService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/QueryService.java
@@ -12,6 +12,7 @@ package io.axoniq.axonserver.grpc;
 import io.axoniq.axonserver.applicationevents.SubscriptionEvents;
 import io.axoniq.axonserver.applicationevents.SubscriptionQueryEvents.SubscriptionQueryResponseReceived;
 import io.axoniq.axonserver.applicationevents.TopologyEvents.QueryHandlerDisconnected;
+import io.axoniq.axonserver.exception.ExceptionUtils;
 import io.axoniq.axonserver.grpc.query.QueryProviderInbound;
 import io.axoniq.axonserver.grpc.query.QueryProviderOutbound;
 import io.axoniq.axonserver.grpc.query.QueryRequest;
@@ -157,7 +158,7 @@ public class QueryService extends QueryServiceGrpc.QueryServiceImplBase implemen
 
             @Override
             public void onError(Throwable cause) {
-                if (!GrpcExceptionBuilder.isCancelled(cause)) {
+                if (!ExceptionUtils.isCancelled(cause)) {
                     logger.warn("{}: Error on connection from subscriber - {}", client, cause.getMessage());
                 }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/QueryService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/QueryService.java
@@ -12,7 +12,15 @@ package io.axoniq.axonserver.grpc;
 import io.axoniq.axonserver.applicationevents.SubscriptionEvents;
 import io.axoniq.axonserver.applicationevents.SubscriptionQueryEvents.SubscriptionQueryResponseReceived;
 import io.axoniq.axonserver.applicationevents.TopologyEvents.QueryHandlerDisconnected;
-import io.axoniq.axonserver.grpc.query.*;
+import io.axoniq.axonserver.grpc.query.QueryProviderInbound;
+import io.axoniq.axonserver.grpc.query.QueryProviderOutbound;
+import io.axoniq.axonserver.grpc.query.QueryRequest;
+import io.axoniq.axonserver.grpc.query.QueryResponse;
+import io.axoniq.axonserver.grpc.query.QueryServiceGrpc;
+import io.axoniq.axonserver.grpc.query.QuerySubscription;
+import io.axoniq.axonserver.grpc.query.SubscriptionQuery;
+import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
+import io.axoniq.axonserver.grpc.query.SubscriptionQueryResponse;
 import io.axoniq.axonserver.message.ClientIdentification;
 import io.axoniq.axonserver.message.query.DirectQueryHandler;
 import io.axoniq.axonserver.message.query.QueryDispatcher;
@@ -26,10 +34,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PreDestroy;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.PreDestroy;
 
 /**
  * GRPC service to handle query bus requests from Axon Application
@@ -149,7 +157,9 @@ public class QueryService extends QueryServiceGrpc.QueryServiceImplBase implemen
 
             @Override
             public void onError(Throwable cause) {
-                logger.warn("{}: Error on connection from subscriber - {}", client, cause.getMessage());
+                if (!GrpcExceptionBuilder.isCancelled(cause)) {
+                    logger.warn("{}: Error on connection from subscriber - {}", client, cause.getMessage());
+                }
 
                 cleanup();
             }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -9,6 +9,7 @@
 
 package io.axoniq.axonserver.localstorage;
 
+import io.axoniq.axonserver.exception.ConcurrencyExceptions;
 import io.axoniq.axonserver.exception.ErrorCode;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
 import io.axoniq.axonserver.grpc.GrpcExceptionBuilder;
@@ -183,10 +184,11 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
             }
 
             private Void error(Throwable exception) {
+                exception = ConcurrencyExceptions.unwrap(exception);
                 if( isClientException(exception)) {
-                    logger.warn("Error while storing events: {}", exception.getMessage());
+                    logger.info("{}: Error while storing events: {}", context, exception.getMessage());
                 } else {
-                    logger.warn("Error while storing events", exception);
+                    logger.warn("{}: Error while storing events", context, exception);
                 }
                 responseObserver.onError(exception);
                 return null;

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -482,8 +482,7 @@ public class EventDispatcher implements AxonServerClientService {
             if (!GrpcExceptionBuilder.isCancelled(reason)) {
                 logger.warn("Error on connection from client: {}", reason.getMessage());
             }
-            StreamObserverUtils.complete(eventStoreRequestObserver);
-            removeTrackerInfo();
+            cleanup();
         }
 
         private void removeTrackerInfo() {
@@ -500,9 +499,13 @@ public class EventDispatcher implements AxonServerClientService {
 
         @Override
         public void onCompleted() {
+            cleanup();
+            StreamObserverUtils.complete(responseObserver);
+        }
+
+        private void cleanup() {
             StreamObserverUtils.complete(eventStoreRequestObserver);
             removeTrackerInfo();
-            StreamObserverUtils.complete(responseObserver);
         }
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -457,7 +457,7 @@ public class EventDispatcher implements AxonServerClientService {
 
                                 @Override
                                 public void onCompleted() {
-                                    logger.warn("{}: Tracking event processor closed by leader", trackerInfo.context);
+                                    logger.info("{}: Tracking event processor closed", trackerInfo.context);
                                     removeTrackerInfo();
                                     StreamObserverUtils.complete(responseObserver);
                                 }
@@ -479,10 +479,10 @@ public class EventDispatcher implements AxonServerClientService {
 
         @Override
         public void onError(Throwable reason) {
-            logger.warn("Error on connection from client: {}", reason.getMessage());
-            if (eventStoreRequestObserver != null) {
-                StreamObserverUtils.complete(eventStoreRequestObserver);
+            if (!GrpcExceptionBuilder.isCancelled(reason)) {
+                logger.warn("Error on connection from client: {}", reason.getMessage());
             }
+            StreamObserverUtils.complete(eventStoreRequestObserver);
             removeTrackerInfo();
         }
 
@@ -500,9 +500,7 @@ public class EventDispatcher implements AxonServerClientService {
 
         @Override
         public void onCompleted() {
-            if (eventStoreRequestObserver != null) {
-                StreamObserverUtils.complete(eventStoreRequestObserver);
-            }
+            StreamObserverUtils.complete(eventStoreRequestObserver);
             removeTrackerInfo();
             StreamObserverUtils.complete(responseObserver);
         }

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -11,6 +11,7 @@ package io.axoniq.axonserver.message.event;
 
 import io.axoniq.axonserver.applicationevents.TopologyEvents;
 import io.axoniq.axonserver.exception.ErrorCode;
+import io.axoniq.axonserver.exception.ExceptionUtils;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
 import io.axoniq.axonserver.grpc.AxonServerClientService;
 import io.axoniq.axonserver.grpc.ContextProvider;
@@ -479,7 +480,7 @@ public class EventDispatcher implements AxonServerClientService {
 
         @Override
         public void onError(Throwable reason) {
-            if (!GrpcExceptionBuilder.isCancelled(reason)) {
+            if (!ExceptionUtils.isCancelled(reason)) {
                 logger.warn("Error on connection from client: {}", reason.getMessage());
             }
             cleanup();

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/ForwardingStreamObserver.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/ForwardingStreamObserver.java
@@ -14,7 +14,9 @@ import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 
 /**
+ * Wraps a {@link StreamObserver} to translate errors to standard exceptions ({@link io.grpc.StatusRuntimeException} with error code in meta data).
  * @author Marc Gathier
+ * @since 4.0
  */
 public class ForwardingStreamObserver<T> implements StreamObserver<T> {
 
@@ -36,7 +38,7 @@ public class ForwardingStreamObserver<T> implements StreamObserver<T> {
 
     @Override
     public void onError(Throwable cause) {
-        logger.warn(EventDispatcher.ERROR_ON_CONNECTION_FROM_EVENT_STORE, request, cause.getMessage());
+        logger.debug(EventDispatcher.ERROR_ON_CONNECTION_FROM_EVENT_STORE, request, cause.getMessage());
         responseObserver.onError(GrpcExceptionBuilder.build(cause));
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/util/StreamObserverUtils.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/util/StreamObserverUtils.java
@@ -21,7 +21,7 @@ public class StreamObserverUtils {
             if (responseStreamObserver != null) {
                 responseStreamObserver.onCompleted();
             }
-        } catch (Throwable t) {
+        } catch (Exception t) {
             // Ignore errors here
         }
     }
@@ -31,7 +31,7 @@ public class StreamObserverUtils {
             if (responseStreamObserver != null) {
                 responseStreamObserver.onError(cause);
             }
-        } catch (Throwable t) {
+        } catch (Exception t) {
             // Ignore errors here
         }
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/util/StreamObserverUtils.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/util/StreamObserverUtils.java
@@ -12,27 +12,38 @@ package io.axoniq.axonserver.util;
 import io.grpc.stub.StreamObserver;
 
 /**
+ * Utility class to do a safe onComplete/onError on a response stream.
  * @author Marc Gathier
  */
 public class StreamObserverUtils {
 
+    /**
+     * Completes a gRPC stream, ignoring any errors that may occur during the complete.
+     *
+     * @param responseStreamObserver the streamObserver to complete
+     */
     public static void complete(StreamObserver<?> responseStreamObserver) {
         try {
             if (responseStreamObserver != null) {
                 responseStreamObserver.onCompleted();
             }
         } catch (Exception t) {
-            // Ignore errors here
+            // Ignore errors here, stream may already have been cancelled/closed before
         }
     }
 
+    /**
+     * Errors a gRPC stream, ignoring any errors that may occur during the sending of the error.
+     * @param responseStreamObserver the streamObserver to error
+     * @param cause the reason why the stream should send an error
+     */
     public static void error(StreamObserver<?> responseStreamObserver, Throwable cause) {
         try {
             if (responseStreamObserver != null) {
                 responseStreamObserver.onError(cause);
             }
         } catch (Exception t) {
-            // Ignore errors here
+            // Ignore errors here, stream may already be cancelled
         }
     }
 }


### PR DESCRIPTION
No longer log invalid sequence number exceptions at warning level.
No longer log warnings when client disconnects.