### PR TITLE
Exception in spring event handler operation causes other handlers not to be executed

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
@@ -32,10 +32,16 @@ import io.axoniq.axonserver.topology.DefaultEventStoreLocator;
 import io.axoniq.axonserver.topology.DefaultTopology;
 import io.axoniq.axonserver.topology.EventStoreLocator;
 import io.axoniq.axonserver.topology.Topology;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -50,6 +56,8 @@ import java.util.Set;
  */
 @Configuration
 public class AxonServerStandardConfiguration {
+
+    private final Logger logger = LoggerFactory.getLogger(AxonServerStandardConfiguration.class);
 
     @Bean
     @ConditionalOnMissingBean(StorageTransactionManagerFactory.class)
@@ -149,4 +157,17 @@ public class AxonServerStandardConfiguration {
         return Clock.systemUTC();
     }
 
+    @Bean
+    public ApplicationEventMulticaster applicationEventMulticaster() {
+        return new SimpleApplicationEventMulticaster() {
+            @Override
+            protected void invokeListener(ApplicationListener<?> listener, ApplicationEvent event) {
+                try {
+                    super.invokeListener(listener, event);
+                } catch (RuntimeException ex) {
+                    logger.warn("Invoking listener {} failed", listener, ex);
+                }
+            }
+        };
+    }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/QueryService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/QueryService.java
@@ -238,7 +238,11 @@ public class QueryService extends QueryServiceGrpc.QueryServiceImplBase implemen
 
         @Override
         public void onNext(QueryResponse queryResponse) {
-            responseObserver.onNext(queryResponse);
+            try {
+                responseObserver.onNext(queryResponse);
+            } catch (Exception ex) {
+                logger.debug("Sending response failed", ex);
+            }
         }
 
         @Override

--- a/axonserver/src/main/resources/axonserver.yml
+++ b/axonserver/src/main/resources/axonserver.yml
@@ -24,6 +24,7 @@ logging:
     root: WARN
     io.axoniq.axonserver.AxonServer: INFO
     io.axoniq.axonserver.grpc.Gateway: INFO
+    io.axoniq.axonserver.logging: INFO
     io.axoniq.axonserver.grpc.internal.MessagingClusterServer: INFO
     org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
     org.springframework.http.converter.json.Jackson2ObjectMapperBuilder: ERROR


### PR DESCRIPTION
If there is an exception in one of the event handlers for a specific class, subsequent event handlers are not executed, causing an inconsistent state. 
This particular instance was when a client application that was both query requester and handler was disconnected while it still had pending queries, as sending the response that the query failed did in its turn cause an exception. 
After that, some of the information of the disconnected application was still present in Axon Server, causing timeouts/handler not found exceptions.

The change prevents an exception in one handler from stopping execution of other event handlers, and also fixes the exception in the query handling.