### PR TITLE
Delete context without data

### DIFF
--- a/axonserver-cli/pom.xml
+++ b/axonserver-cli/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.1</version>
+            <version>2.9.10.1</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/axonserver-cli/src/main/java/io/axoniq/cli/CommandOptions.java
+++ b/axonserver-cli/src/main/java/io/axoniq/cli/CommandOptions.java
@@ -31,6 +31,8 @@ public class CommandOptions {
     public static final Option NODES = Option.builder("n").hasArgs().valueSeparator(',').longOpt("nodes").desc("[Optional - Enterprise Edition only] member nodes for context").build();
     public static final Option CONTEXT_TO_REGISTER_IN = Option.builder("c").longOpt("context").hasArg().desc("[Optional - Enterprise Edition only] context to register node in").build();
     public static final Option DONT_REGISTER_IN_CONTEXTS = Option.builder().longOpt("no-contexts").desc("[Optional - Enterprise Edition only] add node to cluster, but don't register it in any contexts").build();
+    public static final Option PRESERVE_EVENT_STORE = Option.builder().longOpt("preserve-event-store").desc(
+            "[Optional - Enterprise Edition only] keep event store contents").build();
     public static final Option INTERNALHOST = Option.builder("h").longOpt("internal-host").desc("Internal hostname of the node").required().hasArg().build();
     public static final Option INTERNALPORT = Option.builder("p").longOpt("internal-port").desc("Internal port of the node (default 8224)").type(PatternOptionBuilder.NUMBER_VALUE).hasArg().build();
     public static final Option TOKEN = Option.builder("t").longOpt("access-token").desc("[Optional] Access token to authenticate at server").hasArg().build();

--- a/axonserver-cli/src/main/java/io/axoniq/cli/DeleteNodeFromContext.java
+++ b/axonserver-cli/src/main/java/io/axoniq/cli/DeleteNodeFromContext.java
@@ -14,20 +14,28 @@ import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.IOException;
 
-import static io.axoniq.cli.CommandOptions.CONTEXT;
-import static io.axoniq.cli.CommandOptions.NODENAME;
+import static io.axoniq.cli.CommandOptions.*;
 
 /**
  * @author Marc Gathier
  */
 public class DeleteNodeFromContext extends AxonIQCliCommand {
+
     public static void run(String[] args) throws IOException {
         // check args
-        CommandLine commandLine = processCommandLine(args[0], args, CONTEXT, NODENAME, CommandOptions.TOKEN);
+        CommandLine commandLine = processCommandLine(args[0],
+                                                     args,
+                                                     CONTEXT,
+                                                     NODENAME,
+                                                     PRESERVE_EVENT_STORE,
+                                                     CommandOptions.TOKEN);
 
         String url = createUrl(commandLine, "/v1/context", CONTEXT, NODENAME);
 
-        try (CloseableHttpClient httpclient = createClient(commandLine) ) {
+        if (commandLine.hasOption(PRESERVE_EVENT_STORE.getLongOpt())) {
+            url += "?preserveEventStore=true";
+        }
+        try (CloseableHttpClient httpclient = createClient(commandLine)) {
             delete(httpclient, url, 202, getToken(commandLine));
         }
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
@@ -12,11 +12,14 @@ package io.axoniq.axonserver.config;
 import io.axoniq.axonserver.access.jpa.User;
 import io.axoniq.axonserver.access.jpa.UserRole;
 import io.axoniq.axonserver.access.user.UserController;
+import io.axoniq.axonserver.access.user.UserControllerFacade;
 import io.axoniq.axonserver.applicationevents.UserEvents;
 import io.axoniq.axonserver.exception.ErrorCode;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
+import io.axoniq.axonserver.localstorage.EventStoreExistChecker;
 import io.axoniq.axonserver.localstorage.EventStoreFactory;
 import io.axoniq.axonserver.localstorage.LocalEventStore;
+import io.axoniq.axonserver.localstorage.file.DatafileEventStoreExistChecker;
 import io.axoniq.axonserver.localstorage.file.EmbeddedDBProperties;
 import io.axoniq.axonserver.localstorage.file.LowMemoryEventStoreFactory;
 import io.axoniq.axonserver.localstorage.transaction.DefaultStorageTransactionManagerFactory;
@@ -27,7 +30,6 @@ import io.axoniq.axonserver.message.query.QueryHandlerSelector;
 import io.axoniq.axonserver.message.query.RoundRobinQueryHandlerSelector;
 import io.axoniq.axonserver.metric.DefaultMetricCollector;
 import io.axoniq.axonserver.metric.MetricCollector;
-import io.axoniq.axonserver.access.user.UserControllerFacade;
 import io.axoniq.axonserver.topology.DefaultEventStoreLocator;
 import io.axoniq.axonserver.topology.DefaultTopology;
 import io.axoniq.axonserver.topology.EventStoreLocator;
@@ -98,6 +100,12 @@ public class AxonServerStandardConfiguration {
     @ConditionalOnMissingBean(FeatureChecker.class)
     public FeatureChecker featureChecker() {
         return new FeatureChecker() {};
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(EventStoreExistChecker.class)
+    public EventStoreExistChecker eventStoreExistChecker(EmbeddedDBProperties embeddedDBProperties) {
+        return new DatafileEventStoreExistChecker(embeddedDBProperties);
     }
 
     @Bean

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/PlatformService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/PlatformService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * gRPC service to track connected applications. Each application will first call the openStream operation with a
@@ -282,6 +283,18 @@ public class PlatformService extends PlatformServiceGrpc.PlatformServiceImplBase
      */
     public Set<ClientComponent> getConnectedClients() {
         return connectionMap.keySet();
+    }
+
+    /**
+     * Finds all clients that are currently connected to the specified context and requests these client to reconnect.
+     *
+     * @param context the context
+     */
+    public void requestReconnectForContext(String context) {
+        Set<ClientComponent> clients = connectionMap.keySet().stream().filter(c -> c.context.equals(context)).collect(
+                Collectors.toSet());
+
+        clients.forEach(this::requestReconnect);
     }
 
     /**

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStoreExistChecker.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStoreExistChecker.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.localstorage;
+
+/**
+ * @author Marc Gathier
+ */
+public interface EventStoreExistChecker {
+
+    /**
+     * Checks if a context exists on the Axon Server node. Does not create an EventStorageEngine.
+     *
+     * @param context
+     * @return
+     */
+    default boolean exists(String context) {
+        return true;
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStoreFactory.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStoreFactory.java
@@ -9,8 +9,6 @@
 
 package io.axoniq.axonserver.localstorage;
 
-import io.axoniq.axonserver.localstorage.transaction.StorageTransactionManager;
-
 /**
  * Defines the interface to configure an event store for a specific context.
  * @author Marc Gathier
@@ -31,14 +29,4 @@ public interface EventStoreFactory {
      */
     EventStorageEngine createSnapshotStorageEngine(String context);
 
-    /**
-     * Creates a transaction manager for a specific storage engine.
-     * @param eventStorageEngine the storage engine
-     * @return the transaction manager
-     */
-    StorageTransactionManager createTransactionManager(EventStorageEngine eventStorageEngine);
-
-    default boolean exists(String context) {
-        return true;
-    }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStoreFactory.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStoreFactory.java
@@ -37,4 +37,8 @@ public interface EventStoreFactory {
      * @return the transaction manager
      */
     StorageTransactionManager createTransactionManager(EventStorageEngine eventStorageEngine);
+
+    default boolean exists(String context) {
+        return true;
+    }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -26,6 +26,7 @@ import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrRequest;
 import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrResponse;
 import io.axoniq.axonserver.grpc.event.TrackingToken;
 import io.axoniq.axonserver.localstorage.query.QueryEventsRequestStreamObserver;
+import io.axoniq.axonserver.localstorage.transaction.StorageTransactionManagerFactory;
 import io.axoniq.axonserver.util.StreamObserverUtils;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
@@ -69,6 +70,8 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
     @Value("${axoniq.axonserver.new-permits-timeout:120000}")
     private long newPermitsTimeout=120000;
 
+    private final StorageTransactionManagerFactory storageTransactionManagerFactory;
+    private final EventStoreExistChecker eventStoreExistChecker;
     private final int maxEventCount;
 
     /**
@@ -77,15 +80,21 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
      */
     private final int blacklistedSendAfter;
 
-    public LocalEventStore(EventStoreFactory eventStoreFactory) {
-        this(eventStoreFactory, Short.MAX_VALUE, 1000);
+    public LocalEventStore(EventStoreFactory eventStoreFactory,
+                           StorageTransactionManagerFactory storageTransactionManagerFactory,
+                           EventStoreExistChecker eventStoreExistChecker) {
+        this(eventStoreFactory, storageTransactionManagerFactory, eventStoreExistChecker, Short.MAX_VALUE, 1000);
     }
 
     @Autowired
     public LocalEventStore(EventStoreFactory eventStoreFactory,
+                           StorageTransactionManagerFactory storageTransactionManagerFactory,
+                           EventStoreExistChecker eventStoreExistChecker,
                            @Value("${axoniq.axonserver.max-events-per-transaction:32767}") int maxEventCount,
                            @Value("${axoniq.axonserver.blacklisted-send-after:1000}") int blacklistedSendAfter) {
         this.eventStoreFactory = eventStoreFactory;
+        this.storageTransactionManagerFactory = storageTransactionManagerFactory;
+        this.eventStoreExistChecker = eventStoreExistChecker;
         this.maxEventCount = Math.min(maxEventCount, Short.MAX_VALUE);
         this.blacklistedSendAfter = blacklistedSendAfter;
     }
@@ -366,7 +375,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
     }
 
     private Workers openIfExist(String context) {
-        if (this.eventStoreFactory.exists(context)) {
+        if (this.eventStoreExistChecker.exists(context)) {
             Workers workers = new Workers(context);
             workers.init(false);
             return workers;
@@ -463,8 +472,10 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
             this.eventStorageEngine = eventStoreFactory.createEventStorageEngine(context);
             this.snapshotStorageEngine = eventStoreFactory.createSnapshotStorageEngine(context);
             this.context = context;
-            this.eventWriteStorage = new EventWriteStorage(eventStoreFactory.createTransactionManager(this.eventStorageEngine));
-            this.snapshotWriteStorage = new SnapshotWriteStorage(eventStoreFactory.createTransactionManager(this.snapshotStorageEngine));
+            this.eventWriteStorage = new EventWriteStorage(storageTransactionManagerFactory
+                                                                   .createTransactionManager(this.eventStorageEngine));
+            this.snapshotWriteStorage = new SnapshotWriteStorage(storageTransactionManagerFactory
+                                                                         .createTransactionManager(this.snapshotStorageEngine));
             this.aggregateReader = new AggregateReader(eventStorageEngine, new SnapshotReader(snapshotStorageEngine));
             this.trackingEventManager = new TrackingEventProcessorManager(eventStorageEngine, blacklistedSendAfter);
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/DatafileEventStoreExistChecker.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/DatafileEventStoreExistChecker.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.localstorage.file;
+
+import io.axoniq.axonserver.localstorage.EventStoreExistChecker;
+
+import java.io.File;
+
+/**
+ * Component to check if an event store exists for a specific context, without actually opening it.
+ *
+ * @author Marc Gathier
+ * @since 4.3
+ */
+public class DatafileEventStoreExistChecker implements EventStoreExistChecker {
+
+    private final EmbeddedDBProperties embeddedDBProperties;
+
+    public DatafileEventStoreExistChecker(EmbeddedDBProperties embeddedDBProperties) {
+        this.embeddedDBProperties = embeddedDBProperties;
+    }
+
+    @Override
+    public boolean exists(String context) {
+        String folder = embeddedDBProperties.getEvent().getStorage(context);
+        File events = new File(folder);
+        if (!events.isDirectory()) {
+            return false;
+        }
+
+        String[] files = events.list((dir, name) -> name.endsWith(embeddedDBProperties.getEvent().getEventsSuffix()));
+        return files != null && files.length > 0;
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/LowMemoryEventStoreFactory.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/LowMemoryEventStoreFactory.java
@@ -13,7 +13,6 @@ import io.axoniq.axonserver.localstorage.EventStorageEngine;
 import io.axoniq.axonserver.localstorage.EventStoreFactory;
 import io.axoniq.axonserver.localstorage.EventType;
 import io.axoniq.axonserver.localstorage.EventTypeContext;
-import io.axoniq.axonserver.localstorage.transaction.StorageTransactionManager;
 import io.axoniq.axonserver.localstorage.transaction.StorageTransactionManagerFactory;
 import io.axoniq.axonserver.localstorage.transformation.EventTransformerFactory;
 
@@ -52,10 +51,5 @@ public class LowMemoryEventStoreFactory implements EventStoreFactory {
                                                                  embeddedDBProperties.getEvent());
         first.next(second);
         return first;
-    }
-
-    @Override
-    public StorageTransactionManager createTransactionManager(EventStorageEngine eventStorageEngine) {
-        return storageTransactionManagerFactory.createTransactionManager(eventStorageEngine);
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/svg/mapping/Applications.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/svg/mapping/Applications.java
@@ -64,7 +64,12 @@ public class Applications implements Iterable<Application> {
     @Override
     @Nonnull
     public Iterator<Application> iterator() {
-        List<Map.Entry<ComponentContext, Set<ConnectedClient>>> sortedComponents = clientsPerComponent.entrySet().stream().sorted(
+        List<Map.Entry<ComponentContext, Set<ConnectedClient>>> sortedComponents = clientsPerComponent.entrySet()
+                                                                                                      .stream()
+                                                                                                      .filter(c -> clusterController
+                                                                                                              .validContext(
+                                                                                                                      c.getKey().context))
+                                                                                                      .sorted(
                 (o1, o2) -> {
                     ConnectedClient client1 = o1.getValue().stream().min(Comparator.comparing(v -> v.axonHubServer))
                                                               .orElse(new ConnectedClient("", "ZZZZ"));

--- a/axonserver/src/main/java/io/axoniq/axonserver/topology/Topology.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/topology/Topology.java
@@ -75,4 +75,8 @@ public interface Topology {
     default Iterable<String> getMyStorageContextNames() {
         return getMyContextNames();
     }
+
+    default boolean validContext(String context) {
+        return true;
+    }
 }

--- a/axonserver/src/main/resources/static/applications.html
+++ b/axonserver/src/main/resources/static/applications.html
@@ -95,7 +95,7 @@
                         </span>
                     </li>
                     <li>
-                        <span>&nbsp;</span>
+                        <span class="narrow">&nbsp;</span>
                         <span><button @click.prevent="saveApp(application)" class="button">Save</button></span>
                     </li>
                 </ul>

--- a/axonserver/src/main/resources/static/context.html
+++ b/axonserver/src/main/resources/static/context.html
@@ -54,12 +54,6 @@
                             this.removeNodeData = {"node": node, "context": context.context, "preserveData": false};
                             this.$modal.show('delete-node-from-context');
                         }
-                        //
-                        // else if (confirm("Delete node " + node + " from context " + context.context)) {
-                        //     axios.delete("v1/context/" + context.context + "/" + node).then(
-                        //             response => this.loadContexts()
-                        //     )
-                        // }
                     },
                     doDeleteNodeFromContext() {
                         axios.delete("v1/context/" + this.removeNodeData.context + "/" + this.removeNodeData.node
@@ -277,9 +271,9 @@
                         <li>
                             <span>&nbsp;</span>
                             <span>
+                                <button @click.prevent="doDeleteNodeFromContext()" class="button">Remove</button>
                                 <button @click.prevent="hideModal('delete-node-from-context')"
                                         class="button">Cancel</button>
-                                <button @click.prevent="doDeleteNodeFromContext()" class="button">Remove</button>
                             </span>
                         </li>
                     </ul>
@@ -287,7 +281,7 @@
 
             </div>
     </modal>
-    <modal name="delete-context" width="500" height="250">
+    <modal name="delete-context" width="600" height="250">
             <div class="column configuration modal">
                 <h2>Delete context {{deleteContextData.context}}</h2>
                 <p>
@@ -300,10 +294,13 @@
                             <span><input v-model="deleteContextData.retypeContext"/></span>
                         </li>
                         <li>
+                            <span></span>
+                        </li>
+                        <li>
                             <span>&nbsp;</span>
                             <span>
-                                <button @click.prevent="hideModal('delete-context')" class="button">Cancel</button>
                                 <button @click.prevent="doDeleteContext()" class="button">Delete</button>
+                                <button @click.prevent="hideModal('delete-context')" class="button">Cancel</button>
                             </span>
                         </li>
                     </ul>
@@ -311,7 +308,7 @@
 
             </div>
     </modal>
-    <modal name="confirm" width="500" height="250">
+    <modal name="confirm" width="450" height="220">
             <div class="column configuration modal">
                 <h2>{{confirmData.title}}</h2>
                 <p>
@@ -322,8 +319,8 @@
                         <li>
                             <span>&nbsp;</span>
                             <span>
-                                <button @click.prevent="hideModal('confirm')" class="button">Cancel</button>
                                 <button @click.prevent="confirmData.apply()" class="button">OK</button>
+                                <button @click.prevent="hideModal('confirm')" class="button">Cancel</button>
                             </span>
                         </li>
                     </ul>

--- a/axonserver/src/main/resources/static/context.html
+++ b/axonserver/src/main/resources/static/context.html
@@ -18,6 +18,9 @@
                     admin: globals.admin,
                     webSocketInfo: globals.webSocketInfo,
                     nodes: [],
+                    removeNodeData: {},
+                    deleteContextData: {},
+                    confirmData: {},
                     roles: []
                 }, mounted() {
                     this.loadContexts();
@@ -47,12 +50,24 @@
                         if(context.nodes.length == 1) {
                             alert("Cannot delete the last node from " + context.context);
                             return;
+                        } else {
+                            this.removeNodeData = {"node": node, "context": context.context, "preserveData": false};
+                            this.$modal.show('delete-node-from-context');
                         }
-                        else if (confirm("Delete node " + node + " from context " + context.context)) {
-                            axios.delete("v1/context/" + context.context + "/" + node).then(
-                                    response => this.loadContexts()
-                            )
-                        }
+                        //
+                        // else if (confirm("Delete node " + node + " from context " + context.context)) {
+                        //     axios.delete("v1/context/" + context.context + "/" + node).then(
+                        //             response => this.loadContexts()
+                        //     )
+                        // }
+                    },
+                    doDeleteNodeFromContext() {
+                        axios.delete("v1/context/" + this.removeNodeData.context + "/" + this.removeNodeData.node
+                                             + "?preserveEventStore=" + this.removeNodeData.preserveData).then(
+                                response => {
+                                    this.loadContexts();
+                                    this.hideModal('delete-node-from-context');
+                                });
                     },
                     addNodeToContext(context) {
                         if (!context.selectedNode) {
@@ -62,15 +77,28 @@
                             alert("Node already linked to context");
                             return;
                         }
-                        if (confirm("Add node " + context.selectedNode + " to context " + context.context)) {
-                            var queryString = "";
-                            if (context.selectedRole) {
-                                queryString = "?role=" + context.selectedRole;
+
+                        let me = this;
+
+                        this.confirmData = {
+                            "title": "Add node",
+                            "message": "Add node " + context.selectedNode + " to context " + context.context,
+                            "apply": function () {
+                                var queryString = "";
+                                if (context.selectedRole) {
+                                    queryString = "?role=" + context.selectedRole;
+                                }
+                                axios.post("v1/context/" + context.context + "/" + context.selectedNode
+                                                   + queryString).then(
+                                        response => {
+                                            me.loadContexts();
+                                            me.hideModal("confirm");
+                                        }
+                                )
+
                             }
-                            axios.post("v1/context/" + context.context + "/" + context.selectedNode + queryString).then(
-                                    response => this.loadContexts()
-                            )
-                        }
+                        };
+                        this.$modal.show("confirm");
                     },
                     containsSelectedNode(context) {
                         for (var a = 0; a < context.nodes.length; a++) {
@@ -116,12 +144,26 @@
                     deleteContext(context) {
                         if( this.isInternalContext(context) ) {
                             alert("Cannot delete internal context")
-                        } else if (confirm("Delete context " + context.context)) {
-                            axios.delete("v1/context/" + context.context).then(
-                                    response => this.loadContexts()
-                            )
+                        } else {
+                            this.deleteContextData = {"context": context.context, "retypeContext": ""};
+                            this.$modal.show('delete-context');
+                            // } if (confirm("Delete context " + context.context)) {
                         }
-
+                    },
+                    doDeleteContext() {
+                        if (this.deleteContextData.context === this.deleteContextData.retypeContext) {
+                            axios.delete("v1/context/" + this.deleteContextData.context).then(
+                                    response => {
+                                        this.loadContexts();
+                                        this.hideModal('delete-context');
+                                    }
+                            )
+                        } else {
+                            alert('Invalid context name');
+                        }
+                    },
+                    hideModal(name) {
+                        this.$modal.hide(name);
                     },
                     connect() {
                         let me = this;
@@ -189,28 +231,104 @@
     </div>
 
     <section id="applicationDetails" v-if="admin && hasFeature('MULTI_CONTEXT')">
-<div class="column configuration">
-    <form id="contextForm">
-                <ul>
-                    <li>
-                        <span class="narrow">Context Name</span>
-                        <span><input v-model="newContext.context"/></span>
-                    </li>
-                    <li>
-                        <span class="narrow">Nodes</span>
-                        <span>
-                            <div v-for="node in newContext.nodes">
-                                <span class="nodeName">{{node.name}}</span>
-                                <input type="checkbox" v-model="node.selected"/> Add
-                            </div>
-                        </span>
-                    </li>
-                    <li>
-                        <span>&nbsp;</span>
-                        <span><button @click.prevent="createContext()" class="button">Save</button></span>
-                    </li>
-                </ul>
-            </form>
-        </div>
-</section>
+    <div class="column configuration">
+        <form id="contextForm">
+                    <ul>
+                        <li>
+                            <span class="narrow">Context Name</span>
+                            <span><input v-model="newContext.context"/></span>
+                        </li>
+                        <li>
+                            <span class="narrow">Primary Nodes</span>
+                            <span>
+                                <div v-for="node in newContext.nodes">
+                                    <span class="nodeName">{{node.name}}</span>
+                                    <input type="checkbox" v-model="node.selected"/> Add
+                                </div>
+                            </span>
+                        </li>
+                        <li>
+                            <span class="narrow">&nbsp;</span>
+                            <span><button @click.prevent="createContext()" class="button">Save</button></span>
+                        </li>
+                    </ul>
+                </form>
+            </div>
+    </section>
+
+    <modal name="delete-node-from-context" width="500" height="250">
+            <div id="remove-node" class="column configuration modal">
+                <h2>Remove node from context</h2>
+
+                <form>
+                    <ul>
+                        <li>
+                            <span>Context</span>
+                            <span><input disabled v-model="removeNodeData.context"/></span>
+                        </li>
+                        <li>
+                            <span>Node</span>
+                            <span><input disabled v-model="removeNodeData.node"/></span>
+                        </li>
+                        <li>
+                            <span>Preserve Event Store</span>
+                            <span><input type="checkbox" v-model="removeNodeData.preserveData"/></span>
+                        </li>
+                        <li>
+                            <span>&nbsp;</span>
+                            <span>
+                                <button @click.prevent="hideModal('delete-node-from-context')"
+                                        class="button">Cancel</button>
+                                <button @click.prevent="doDeleteNodeFromContext()" class="button">Remove</button>
+                            </span>
+                        </li>
+                    </ul>
+                </form>
+
+            </div>
+    </modal>
+    <modal name="delete-context" width="500" height="250">
+            <div class="column configuration modal">
+                <h2>Delete context {{deleteContextData.context}}</h2>
+                <p>
+                    This will delete all data for this context. Please re-type the name of the context to delete to continue.
+                </p>
+                <form>
+                    <ul>
+                        <li>
+                            <span>Context Name</span>
+                            <span><input v-model="deleteContextData.retypeContext"/></span>
+                        </li>
+                        <li>
+                            <span>&nbsp;</span>
+                            <span>
+                                <button @click.prevent="hideModal('delete-context')" class="button">Cancel</button>
+                                <button @click.prevent="doDeleteContext()" class="button">Delete</button>
+                            </span>
+                        </li>
+                    </ul>
+                </form>
+
+            </div>
+    </modal>
+    <modal name="confirm" width="500" height="250">
+            <div class="column configuration modal">
+                <h2>{{confirmData.title}}</h2>
+                <p>
+                    {{confirmData.message}}
+                </p>
+                <form>
+                    <ul>
+                        <li>
+                            <span>&nbsp;</span>
+                            <span>
+                                <button @click.prevent="hideModal('confirm')" class="button">Cancel</button>
+                                <button @click.prevent="confirmData.apply()" class="button">OK</button>
+                            </span>
+                        </li>
+                    </ul>
+                </form>
+
+            </div>
+    </modal>
 </span>

--- a/axonserver/src/main/resources/static/css/style.css
+++ b/axonserver/src/main/resources/static/css/style.css
@@ -663,6 +663,18 @@ select {
 	width: 100px;
 }
 
+.hidden {
+    display: none;
+}
+
+.modal {
+    padding: 20px;
+}
+
+.modal .button-bar {
+    margin-top: 20px;
+}
+
 @media only screen and (max-width: 1024px){
 	.column-wrapper{
 		display: block;

--- a/axonserver/src/main/resources/static/users.html
+++ b/axonserver/src/main/resources/static/users.html
@@ -91,7 +91,7 @@
                         </span>
                     </li>
                     <li>
-                        <span>&nbsp;</span>
+                        <span class="narrow">&nbsp;</span>
                         <span><button @click.prevent="save(user)" class="button">Save</button></span>
                     </li>
                 </ul>

--- a/axonserver/src/main/vuejs/components/component/Processors.vue
+++ b/axonserver/src/main/vuejs/components/component/Processors.vue
@@ -141,8 +141,8 @@
                         <li>
                             <span>&nbsp;</span>
                             <span>
-                                <button @click.prevent="hideMoveSegment()" class="button">Cancel</button>
                                 <button @click.prevent="moveSegment()" class="button">Move</button>
+                                <button @click.prevent="hideMoveSegment()" class="button">Cancel</button>
                             </span>
                         </li>
                     </ul>
@@ -166,8 +166,8 @@
                         <li>
                             <span>&nbsp;</span>
                             <span class="button-bar">
-                                <button @click.prevent="hideLoadBalance()" class="button">Cancel</button>
                                 <button @click.prevent="loadBalance()" class="button">Balance</button>
+                                <button @click.prevent="hideLoadBalance()" class="button">Cancel</button>
                             </span>
                         </li>
                     </ul>

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStorageEngineTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStorageEngineTest.java
@@ -84,7 +84,7 @@ public class LocalEventStorageEngineTest {
 
     @Test
     public void deleteContext() {
-        testSubject.deleteContext(SAMPLE_CONTEXT);
+        testSubject.deleteContext(SAMPLE_CONTEXT, false);
     }
 
     @Test

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/HttpStreamingQueryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/HttpStreamingQueryTest.java
@@ -12,6 +12,7 @@ package io.axoniq.axonserver.rest;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.EventWithToken;
 import io.axoniq.axonserver.localstorage.EventStorageEngine;
+import io.axoniq.axonserver.localstorage.EventStoreExistChecker;
 import io.axoniq.axonserver.localstorage.EventStoreFactory;
 import io.axoniq.axonserver.localstorage.EventType;
 import io.axoniq.axonserver.localstorage.EventTypeContext;
@@ -20,7 +21,6 @@ import io.axoniq.axonserver.localstorage.Registration;
 import io.axoniq.axonserver.localstorage.SerializedEvent;
 import io.axoniq.axonserver.localstorage.SerializedEventWithToken;
 import io.axoniq.axonserver.localstorage.SerializedTransactionWithToken;
-import io.axoniq.axonserver.localstorage.transaction.StorageTransactionManager;
 import io.axoniq.axonserver.topology.DefaultEventStoreLocator;
 import io.axoniq.axonserver.topology.EventStoreLocator;
 import io.axoniq.axonserver.topology.Topology;
@@ -129,6 +129,7 @@ public class HttpStreamingQueryTest {
 
             }
         };
+
         LocalEventStore localEventStore = new LocalEventStore(new EventStoreFactory() {
             @Override
             public EventStorageEngine createEventStorageEngine(String context) {
@@ -139,11 +140,7 @@ public class HttpStreamingQueryTest {
             public EventStorageEngine createSnapshotStorageEngine(String context) {
                 return engine;
             }
-
-            @Override
-            public StorageTransactionManager createTransactionManager(EventStorageEngine eventStorageEngine) {
-                return null;
-            }
+        }, eventStore -> null, new EventStoreExistChecker() {
         });
         localEventStore.initContext(Topology.DEFAULT_CONTEXT, false);
         EventStoreLocator eventStoreLocator = new DefaultEventStoreLocator(localEventStore);


### PR DESCRIPTION
UI and CLI changes to support removing a node from context without deleting the event store.
SyncEvents and SyncSnapshots can now initialize the event store if necessary. 
getLastEvent/getLastSnapshot will check to see if there is an event store available but not yet opened.