### PR TITLE
Changes to avoid warnings

### DIFF
--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -57,10 +57,6 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
         <dependency>
-            <groupId>nz.net.ultraq.thymeleaf</groupId>
-            <artifactId>thymeleaf-layout-dialect</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
         </dependency>
@@ -167,7 +163,6 @@
             <groupId>org.mindrot</groupId>
             <artifactId>jbcrypt</artifactId>
             <version>0.4</version>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -191,20 +186,26 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.0.1</version>
         </dependency>
+        <!-- required for integration test -->
         <dependency>
             <groupId>org.axonframework</groupId>
             <artifactId>axon-spring-boot-starter</artifactId>
             <version>4.1.2</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-core</artifactId>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
         </dependency>
 
         <!-- logback json deps to support json logging (#59) -->

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/CleanUtils.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/CleanUtils.java
@@ -40,9 +40,8 @@ public class CleanUtils {
     private static final int RETRIES = 5;
     private static final boolean java8 = System.getProperty("java.version").startsWith("1.8");
 
-    private static boolean cleanOldsJDK(final ByteBuffer buffer) {
-        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-            Boolean success = Boolean.FALSE;
+    private static void cleanOldsJDK(final ByteBuffer buffer) {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             try {
                 Method getCleanerMethod = buffer.getClass().getMethod("cleaner", (Class[]) null);
                 if (!getCleanerMethod.isAccessible()) {
@@ -51,17 +50,15 @@ public class CleanUtils {
                 Object cleaner = getCleanerMethod.invoke(buffer, (Object[]) null);
                 Method clean = cleaner.getClass().getMethod("clean", (Class[]) null);
                 clean.invoke(cleaner, (Object[]) null);
-                success = Boolean.TRUE;
             } catch (Exception ex) {
                 logger.warn("Clean failed", ex);
             }
-            return success;
+            return null;
         });
     }
 
-    private static boolean cleanJavaWithModules(final java.nio.ByteBuffer buffer) {
-        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-            Boolean success = Boolean.FALSE;
+    private static void cleanJavaWithModules(final java.nio.ByteBuffer buffer) {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             try {
                 final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
                 final Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
@@ -69,11 +66,10 @@ public class CleanUtils {
                 final Object theUnsafe = theUnsafeField.get(null);
                 final Method invokeCleanerMethod = unsafeClass.getMethod("invokeCleaner", ByteBuffer.class);
                 invokeCleanerMethod.invoke(theUnsafe, buffer);
-                success = Boolean.TRUE;
             } catch (Exception ex) {
                 logger.warn("Clean failed", ex);
             }
-            return success;
+            return null;
         });
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/CleanUtils.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/CleanUtils.java
@@ -13,9 +13,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -23,11 +25,9 @@ import java.util.function.BooleanSupplier;
 
 /**
  * @author Marc Gathier
- * Copied code from Tomcat to clean buffer: org.apache.tomcat.util.buf.ByteBufferUtils
+ * @since 4.0
  */
 public class CleanUtils {
-    private static final Method cleanerMethod;
-    private static final Method cleanMethod;
     private static final Logger logger = LoggerFactory.getLogger(CleanUtils.class);
     private static final ScheduledExecutorService cleanupExecutor = Executors.newSingleThreadScheduledExecutor(new CustomizableThreadFactory("fileCleaner") {
         @Override
@@ -38,41 +38,50 @@ public class CleanUtils {
         }
     });
     private static final int RETRIES = 5;
+    private static final boolean java8 = System.getProperty("java.version").startsWith("1.8");
 
-    static {
-        ByteBuffer tempBuffer = ByteBuffer.allocateDirect(0);
-        Method cleanerMethodLocal;
-        Method cleanMethodLocal;
-
-        try {
-            cleanerMethodLocal = tempBuffer.getClass().getMethod("cleaner");
-            cleanerMethodLocal.setAccessible(true);
-            Object cleanerObject = cleanerMethodLocal.invoke(tempBuffer);
-            if (cleanerObject instanceof Runnable) {
-                cleanMethodLocal = Runnable.class.getMethod("run");
-            } else {
-                cleanMethodLocal = cleanerObject.getClass().getMethod("clean");
+    private static boolean cleanOldsJDK(final ByteBuffer buffer) {
+        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+            Boolean success = Boolean.FALSE;
+            try {
+                Method getCleanerMethod = buffer.getClass().getMethod("cleaner", (Class[]) null);
+                if (!getCleanerMethod.isAccessible()) {
+                    getCleanerMethod.setAccessible(true);
+                }
+                Object cleaner = getCleanerMethod.invoke(buffer, (Object[]) null);
+                Method clean = cleaner.getClass().getMethod("clean", (Class[]) null);
+                clean.invoke(cleaner, (Object[]) null);
+                success = Boolean.TRUE;
+            } catch (Exception ex) {
+                logger.warn("Clean failed", ex);
             }
-
-            cleanMethodLocal.invoke(cleanerObject);
-        } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException | IllegalAccessException methodException) {
-            if( logger.isDebugEnabled()) {
-                logger.warn("Unable to configure clean method. If you are running on Windows with a Java version 9 or higher start Axon Server with --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED", methodException);
-            } else {
-                logger.warn("Unable to configure clean method. If you are running on Windows with a Java version 9 or higher start Axon Server with --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED");
-            }
-            cleanerMethodLocal = null;
-            cleanMethodLocal = null;
-        }
-
-        cleanerMethod = cleanerMethodLocal;
-        cleanMethod = cleanMethodLocal;
+            return success;
+        });
     }
+
+    private static boolean cleanJavaWithModules(final java.nio.ByteBuffer buffer) {
+        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+            Boolean success = Boolean.FALSE;
+            try {
+                final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+                final Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
+                theUnsafeField.setAccessible(true);
+                final Object theUnsafe = theUnsafeField.get(null);
+                final Method invokeCleanerMethod = unsafeClass.getMethod("invokeCleaner", ByteBuffer.class);
+                invokeCleanerMethod.invoke(theUnsafe, buffer);
+                success = Boolean.TRUE;
+            } catch (Exception ex) {
+                logger.warn("Clean failed", ex);
+            }
+            return success;
+        });
+    }
+
     private CleanUtils() {
     }
 
     public static void cleanDirectBuffer(ByteBuffer buf, BooleanSupplier allowed, long delay, String file) {
-        if (cleanMethod != null && buf != null) {
+        if (buf != null) {
             if (delay <= 0) {
                 doCleanup(allowed, buf, 10, file, RETRIES);
             } else {
@@ -96,9 +105,13 @@ public class CleanUtils {
             return;
         }
         try {
-            cleanMethod.invoke(cleanerMethod.invoke(buf));
+            if (java8) {
+                cleanOldsJDK(buf);
+            } else {
+                cleanJavaWithModules(buf);
+            }
             logger.debug("Memory mapped buffer cleared for {}", file);
-        } catch (Throwable exception) {
+        } catch (Exception exception) {
             logger.warn("Clean failed", exception);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <netty.version>4.1.35.Final</netty.version>
         <projectreactor.version>3.1.7.RELEASE</projectreactor.version>
         <axonserver.api.version>4.2.2</axonserver.api.version>
+        <h2.version>1.4.197</h2.version>
     </properties>
 
     <dependencyManagement>
@@ -133,6 +134,12 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
                 <version>1.1.11</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Improved cleanutils for java11 support.
updated h2 version to avoid flyway warning on startup.
removed thymeleaf-layout-dialect as it was not used and causing warning on java11
added jackson-module-kotlin and kotlin-refect dependencies to avoid warnings.