### PR TITLE
Fix version information when management.server.port is set

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
@@ -38,6 +38,8 @@ import io.axoniq.axonserver.topology.DefaultEventStoreLocator;
 import io.axoniq.axonserver.topology.DefaultTopology;
 import io.axoniq.axonserver.topology.EventStoreLocator;
 import io.axoniq.axonserver.topology.Topology;
+import io.axoniq.axonserver.version.DefaultVersionInfoProvider;
+import io.axoniq.axonserver.version.VersionInfoProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -187,6 +189,17 @@ public class AxonServerStandardConfiguration {
         return new DefaultInstructionAckSource<>(ack -> QueryProviderInbound.newBuilder()
                                                                             .setAck(ack)
                                                                             .build());
+    }
+
+    /**
+     * Creates a default version information provider bean.
+     *
+     * @return a default version information provider
+     */
+    @Bean
+    @ConditionalOnMissingBean(VersionInfoProvider.class)
+    public VersionInfoProvider versionInfoProvider() {
+        return new DefaultVersionInfoProvider();
     }
 
     @Bean

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/PublicRestController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/PublicRestController.java
@@ -13,6 +13,8 @@ import io.axoniq.axonserver.config.AccessControlConfiguration;
 import io.axoniq.axonserver.config.FeatureChecker;
 import io.axoniq.axonserver.config.MessagingPlatformConfiguration;
 import io.axoniq.axonserver.config.SslConfiguration;
+import io.axoniq.axonserver.version.VersionInfo;
+import io.axoniq.axonserver.version.VersionInfoProvider;
 import io.axoniq.axonserver.message.command.CommandDispatcher;
 import io.axoniq.axonserver.message.event.EventDispatcher;
 import io.axoniq.axonserver.message.query.QueryDispatcher;
@@ -54,6 +56,7 @@ public class PublicRestController {
     private final FeatureChecker features;
     private final SslConfiguration sslConfiguration;
     private final AccessControlConfiguration accessControlConfiguration;
+    private final VersionInfoProvider versionInfoSupplier;
     private final Supplier<SubscriptionMetrics> subscriptionMetricsRegistry;
 
     @Value("${axoniq.axonserver.devmode.enabled:false}")
@@ -66,6 +69,7 @@ public class PublicRestController {
                                 EventDispatcher eventDispatcher,
                                 FeatureChecker features,
                                 MessagingPlatformConfiguration messagingPlatformConfiguration,
+                                VersionInfoProvider versionInfoSupplier,
                                 Supplier<SubscriptionMetrics> subscriptionMetricsRegistry) {
         this.axonServerProvider = axonServerProvider;
         this.topology = topology;
@@ -75,6 +79,7 @@ public class PublicRestController {
         this.features = features;
         this.sslConfiguration = messagingPlatformConfiguration.getSsl();
         this.accessControlConfiguration = messagingPlatformConfiguration.getAccesscontrol();
+        this.versionInfoSupplier = versionInfoSupplier;
         this.subscriptionMetricsRegistry = subscriptionMetricsRegistry;
     }
 
@@ -152,6 +157,12 @@ public class PublicRestController {
         }
 
         return null;
+    }
+
+    @GetMapping(path = "version")
+    @ApiOperation(value = "Retrieves version information of the product")
+    public VersionInfo versionInfo() {
+        return versionInfoSupplier.get();
     }
 
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/version/DefaultVersionInfoProvider.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/version/DefaultVersionInfoProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.version;
+
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * Provides information on the current version of the product.
+ *
+ * @author Marc Gathier
+ * @since 4.2.4
+ */
+public class DefaultVersionInfoProvider implements VersionInfoProvider {
+
+    @Value("${info.app.name:Axon Server}")
+    private String applicationName;
+    @Value("${info.app.version:Unknown}")
+    private String defaultVersion;
+
+    @Override
+    public VersionInfo get() {
+        return new VersionInfo(applicationName, defaultVersion);
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/version/VersionInfo.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/version/VersionInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.version;
+
+/**
+ * Data object containing the product name and version.
+ *
+ * @author Marc Gathier
+ * @since 4.2.4
+ */
+public class VersionInfo {
+
+    private final String productName;
+    private final String version;
+
+    public VersionInfo(String productName, String version) {
+        this.productName = productName;
+        this.version = version;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/version/VersionInfoProvider.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/version/VersionInfoProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.version;
+
+/**
+ * Provides information on the current version of the product.
+ *
+ * @author Marc Gathier
+ * @since 4.2.4
+ */
+public interface VersionInfoProvider {
+
+    /**
+     * Returns the version information.
+     *
+     * @return the product name and version
+     */
+    VersionInfo get();
+}

--- a/axonserver/src/main/resources/static/index.html
+++ b/axonserver/src/main/resources/static/index.html
@@ -108,8 +108,8 @@
                         data: {
                             version: "Version"
                         }, mounted() {
-                    axios.get("actuator/info").then(response => {
-                        this.version = response.data.app.name + " " + response.data.app.version;
+                    axios.get("v1/public/version").then(response => {
+                        this.version = response.data.productName + " " + response.data.version;
                     });
                 }
                     });

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/PublicRestControllerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/PublicRestControllerTest.java
@@ -11,6 +11,7 @@ package io.axoniq.axonserver.rest;
 
 import io.axoniq.axonserver.config.FeatureChecker;
 import io.axoniq.axonserver.config.MessagingPlatformConfiguration;
+import io.axoniq.axonserver.version.DefaultVersionInfoProvider;
 import io.axoniq.axonserver.config.SystemInfoProvider;
 import io.axoniq.axonserver.message.command.CommandDispatcher;
 import io.axoniq.axonserver.message.event.EventDispatcher;
@@ -63,6 +64,7 @@ public class PublicRestControllerTest {
         clusterController = new DefaultTopology(messagePlatformConfiguration);
         testSubject = new PublicRestController(new AxonServers(clusterController, new DefaultEventStoreLocator(null)), clusterController, commandDispatcher, queryDispatcher, eventDispatcher, limits,
                                                messagePlatformConfiguration,
+                                               new DefaultVersionInfoProvider(),
                                                () -> new FakeSubscriptionMetrics(500, 400, 1000));
 
     }


### PR DESCRIPTION
The old mechanism for retrieving the version from UI depended on the actuator info endpoint to run on the same port as the dashboard.

When management.server.port was set to another port it did not work anymore. Created a new endpoint to retrieve version information.