### PR TITLE
Index update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,14 +90,14 @@ podTemplate(label: label,
                         junit '**/target/surefire-reports/TEST-*.xml'                   // Read the test results
                         slackReport = slackReport + "\n" + getTestSummary()
                     }
-                    when(relevantBranch(gitBranch, deployingBranches)) {                // Deploy artifacts to Nexus for some branches
+                    if (relevantBranch(gitBranch, deployingBranches)) {                // Deploy artifacts to Nexus for some branches
                         sh "mvn \${MVN_BLD} -DskipTests deploy"
                     }
                 }
             }
 
             stage ('Run SonarQube') {
-                when(relevantBranch(gitBranch, sonarBranches)) {                        // Run SonarQube analyses for some branches
+                if (relevantBranch(gitBranch, sonarBranches)) {                        // Run SonarQube analyses for some branches
                     container("maven") {
                         sh "mvn \${MVN_BLD} -DskipTests -Psonar sonar:sonar"
                     }
@@ -108,7 +108,7 @@ podTemplate(label: label,
                 /*
                  * Run a subsidiary build to make Docker test images.
                  */
-                when(relevantBranch(gitBranch, dockerBranches)) {
+                if (relevantBranch(gitBranch, dockerBranches)) {
                     def dockerBuild = build job: 'axon-server-dockerimages/master', propagate: false, wait: true,
                         parameters: [
                             string(name: 'groupId', value: pomGroupId),
@@ -126,7 +126,7 @@ podTemplate(label: label,
                 /*
                  * If we have Docker images and artifacts in Nexus, we can run Canary tests on them.
                  */
-                when(relevantBranch(gitBranch, dockerBranches) && relevantBranch(gitBranch, deployingBranches)) {
+                if (relevantBranch(gitBranch, dockerBranches) && relevantBranch(gitBranch, deployingBranches)) {
                     def canaryTests = build job: 'axon-server-canary/master', propagate: false, wait: true,
                         parameters: [
                             string(name: 'groupId', value: pomGroupId),

--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -31,6 +31,7 @@
 
         <mapdb.version>3.0.7</mapdb.version>
         <jackson.version>2.9.10</jackson.version>
+        <skip.integration.tests>true</skip.integration.tests>
     </properties>
 
     <dependencies>
@@ -258,6 +259,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.18.1</version>
+                <configuration>
+                    <skipITs>${skip.integration.tests}</skipITs>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -31,7 +31,7 @@
 
         <mapdb.version>3.0.7</mapdb.version>
         <jackson.version>2.9.10</jackson.version>
-        <skip.integration.tests>true</skip.integration.tests>
+        <skip.integration.tests>false</skip.integration.tests>
     </properties>
 
     <dependencies>

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
@@ -30,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -152,12 +153,16 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
             List<ProcessedEvent> eventList = preparedTransaction.getEventList();
             int eventSize = preparedTransaction.getEventSize();
             WritePosition writePosition = preparedTransaction.getWritePosition();
+            Map<String, SortedSet<PositionInfo>> indexEntries = new HashMap<>();
+
             synchronizer.register(writePosition, new StorageCallback() {
                 private final AtomicBoolean execute = new AtomicBoolean(true);
 
                 @Override
                 public boolean onCompleted(long firstToken) {
                     if (execute.getAndSet(false)) {
+                        positionsPerSegmentMap.computeIfAbsent(writePosition.segment, s -> new HashMap<>()).putAll(
+                                indexEntries);
                         completableFuture.complete(firstToken);
                         lastToken.set(firstToken + eventList.size() - 1);
                         return true;
@@ -170,7 +175,7 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
                     completableFuture.completeExceptionally(cause);
                 }
             });
-            write(writePosition, eventSize, eventList);
+            write(writePosition, eventSize, eventList, indexEntries);
             synchronizer.notifyWritePositions();
         } catch (RuntimeException cause) {
             completableFuture.completeExceptionally(cause);
@@ -329,7 +334,8 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
         }
     }
 
-    private void write(WritePosition writePosition, int eventSize, List<ProcessedEvent> eventList) {
+    private void write(WritePosition writePosition, int eventSize, List<ProcessedEvent> eventList,
+                       Map<String, SortedSet<PositionInfo>> indexEntries) {
         ByteBufferEventSource source = writePosition.buffer.duplicate();
         ByteBuffer writeBuffer = source.getBuffer();
         writeBuffer.position(writePosition.position);
@@ -343,9 +349,9 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
             writeBuffer.putInt(event.getSerializedSize());
             writeBuffer.put(event.toByteArray());
             if (event.isDomainEvent()) {
-                positionsPerSegmentMap.get(writePosition.segment).computeIfAbsent(event.getAggregateIdentifier(),
+                indexEntries.computeIfAbsent(event.getAggregateIdentifier(),
                                                                                   k -> new ConcurrentSkipListSet<>())
-                                      .add(new PositionInfo(position, event.getAggregateSequenceNumber()));
+                            .add(new PositionInfo(position, event.getAggregateSequenceNumber()));
             }
         }
 


### PR DESCRIPTION
when writing an event, only update the index map after the complete event block has completed. Avoids access to the data before write is complete.