### PR TITLE
Feature/insecure cli connections

### DIFF
--- a/axonserver-cli/src/main/java/io/axoniq/cli/AxonIQCliCommand.java
+++ b/axonserver-cli/src/main/java/io/axoniq/cli/AxonIQCliCommand.java
@@ -39,7 +39,6 @@ import java.io.InputStreamReader;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import javax.net.ssl.SSLContext;
 
 
 /**

--- a/axonserver-cli/src/main/java/io/axoniq/cli/AxonIQCliCommand.java
+++ b/axonserver-cli/src/main/java/io/axoniq/cli/AxonIQCliCommand.java
@@ -23,6 +23,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -46,7 +47,11 @@ import javax.net.ssl.SSLContext;
  */
 public class AxonIQCliCommand {
     protected static CommandLine processCommandLine(String name, String[] args, Option... options) {
-        Options cliOptions = new Options().addOption(CommandOptions.ADDRESS).addOption(CommandOptions.OUTPUT);
+        Options cliOptions = new Options()
+                .addOption(CommandOptions.ADDRESS)
+                .addOption(CommandOptions.USE_HTTPS)
+                .addOption(CommandOptions.CONNECT_INSECURE)
+                .addOption(CommandOptions.OUTPUT);
         for (Option option : options) {
             cliOptions.addOption(option);
         }
@@ -63,7 +68,10 @@ public class AxonIQCliCommand {
 
     protected static String createUrl(CommandLine commandLine, String uri, Option... args) {
         String address = commandLine.getOptionValue(CommandOptions.ADDRESS.getOpt());
-        if( address == null) address = "http://localhost:8024";
+        if( address == null) {
+            address = commandLine.hasOption(CommandOptions.USE_HTTPS.getOpt())
+                    ? "https://localhost:8024" : "http://localhost:8024";
+        }
         StringBuilder builder = new StringBuilder();
         builder.append(address).append(uri);
 
@@ -76,14 +84,21 @@ public class AxonIQCliCommand {
     protected static CloseableHttpClient createClient(CommandLine commandLine)  {
         try {
             String address = commandLine.getOptionValue(CommandOptions.ADDRESS.getOpt());
-            if (address == null) address = "http://localhost:8024";
+            if (address == null) {
+                address = commandLine.hasOption(CommandOptions.USE_HTTPS.getOpt())
+                        ? "https://localhost:8024" : "http://localhost:8024";
+            }
             if (address.startsWith("https")) {
-                SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true)
-                                                               .build();
-                return HttpClients.custom()
-                                  .disableRedirectHandling()
-                                  .setSSLContext(sslContext)
-                                  .build();
+                HttpClientBuilder clientBuilder = HttpClients
+                        .custom()
+                        .disableRedirectHandling();
+                if (commandLine.hasOption(CommandOptions.CONNECT_INSECURE.getOpt())) {
+                    clientBuilder
+                            .setSSLContext(new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build())
+                            .setSSLHostnameVerifier(new NoopHostnameVerifier());
+                }
+
+                return clientBuilder.build();
             }
 
             return HttpClientBuilder.create().disableRedirectHandling().build();

--- a/axonserver-cli/src/main/java/io/axoniq/cli/CommandOptions.java
+++ b/axonserver-cli/src/main/java/io/axoniq/cli/CommandOptions.java
@@ -22,116 +22,227 @@ public class CommandOptions {
     /**
      * The base URL for Axon Server admin node.
      */
-    public static final Option ADDRESS = Option.builder("S").hasArg().longOpt("server").desc("Server to send command to (default http://localhost:8024)")
-                                               .build();
+    public static final Option ADDRESS = Option
+            .builder("S")
+            .longOpt("server")
+            .hasArg()
+            .desc("Server to send command to (default http://localhost:8024)")
+            .build();
+
+    /**
+     * Connect to Axon Server using HTTPS instead of HTTP.
+     */
+    public static final Option USE_HTTPS = Option
+            .builder("s")
+            .longOpt("https")
+            .desc("Use HTTPS to connect to the server, rather than HTTP.")
+            .build();
+
+    /**
+     * Connect to Axon Server using HTTPS instead of HTTP.
+     */
+    public static final Option CONNECT_INSECURE = Option
+            .builder("i")
+            .longOpt("insecure-ssl")
+            .desc("Do not check the certificate when connecting using HTTPS.")
+            .build();
+
     /**
      * The name of the application to manage.
      */
-    public static final Option APPLICATION = Option.builder("a").hasArg().longOpt("application").required().desc("Name of the application").build();
+    public static final Option APPLICATION = Option
+            .builder("a")
+            .longOpt("application")
+            .hasArg()
+            .required()
+            .desc("Name of the application")
+            .build();
     /**
      * The roles granted to the application.
      */
-    public static final Option APPLICATION_ROLES = Option.builder("r").required().hasArgs().valueSeparator(',').longOpt(
-            "roles")
-                                                         .desc("Roles for the application, use role@context").build();
+    public static final Option APPLICATION_ROLES = Option
+            .builder("r")
+            .longOpt("roles")
+            .hasArgs().valueSeparator(',')
+            .required()
+            .desc("Roles for the application, use role@context")
+            .build();
     /**
      * The roles granted to the user.
      */
-    public static final Option USER_ROLES = Option.builder("r").hasArgs().valueSeparator(',').longOpt("roles").desc(
-            "[Optional] roles for the user").build();
+    public static final Option USER_ROLES = Option
+            .builder("r")
+            .longOpt("roles")
+            .hasArgs().valueSeparator(',')
+            .desc("[Optional] roles for the user")
+            .build();
     /**
      * The description of the application.
      */
-    public static final Option APPLICATION_DESCRIPTION = Option.builder("d").hasArgs().longOpt("description").desc(
-            "[Optional] Description of the application").build();
+    public static final Option APPLICATION_DESCRIPTION = Option
+            .builder("d")
+            .longOpt("description")
+            .hasArgs() // space separator
+            .desc("[Optional] Description of the application")
+            .build();
     /**
      * The name of the node to add/remove from the context.
      */
-    public static final Option NODE_NAME = Option.builder("n").longOpt("node").required().hasArg().desc(
-            "Name of the node").build();
+    public static final Option NODE_NAME = Option
+            .builder("n")
+            .longOpt("node")
+            .hasArg()
+            .required()
+            .desc("Name of the node")
+            .build();
     /**
      * The role of the node in the context.
      */
-    public static final Option NODE_ROLE = Option.builder("r").longOpt("role").hasArg().desc(
-            "Role of the node (PRIMARY,MESSAGING_ONLY,ACTIVE_BACKUP,PASSIVE_BACKUP").build();
+    public static final Option NODE_ROLE = Option
+            .builder("r")
+            .longOpt("role")
+            .hasArg()
+            .desc("Role of the node (PRIMARY,MESSAGING_ONLY,ACTIVE_BACKUP,PASSIVE_BACKUP")
+            .build();
     /**
      * The name of the context.
      */
-    public static final Option CONTEXT = Option.builder("c").longOpt("context").required().hasArg().desc(
-            "Name of the context").build();
+    public static final Option CONTEXT = Option
+            .builder("c")
+            .longOpt("context")
+            .required()
+            .hasArg()
+            .desc("Name of the context")
+            .build();
     /**
      * Comma separated list of Axon Server node names as primary members for the context.
      */
-    public static final Option NODES = Option.builder("n")
-                                             .hasArgs()
-                                             .valueSeparator(',')
-                                             .longOpt("nodes")
-                                             .required()
-                                             .desc("[Enterprise Edition only] primary member nodes for context")
-                                             .build();
+    public static final Option NODES = Option
+            .builder("n")
+            .longOpt("nodes")
+            .hasArgs().valueSeparator(',')
+            .required()
+            .desc("[Enterprise Edition only] primary member nodes for context")
+            .build();
     /**
      * Comma separated list of Axon Server node names as active backup nodes for the context.
      */
-    public static final Option ACTIVE_BACKUP_NODES = Option.builder("a").hasArgs().valueSeparator(',').longOpt(
-            "active-backup").desc("[Optional - Enterprise Edition only] active backup member nodes for context")
-                                                           .build();
+    public static final Option ACTIVE_BACKUP_NODES = Option
+            .builder("a")
+            .longOpt("active-backup")
+            .hasArgs().valueSeparator(',')
+            .desc("[Optional - Enterprise Edition only] active backup member nodes for context")
+            .build();
     /**
      * Comma separated list of Axon Server node names as passive backup nodes for the context.
      */
-    public static final Option PASSIVE_BACKUP_NODES = Option.builder("p").hasArgs().valueSeparator(',').longOpt(
-            "passive-backup").desc("[Optional - Enterprise Edition only] passive backup member nodes for context")
-                                                            .build();
+    public static final Option PASSIVE_BACKUP_NODES = Option
+            .builder("p")
+            .longOpt("passive-backup")
+            .hasArgs().valueSeparator(',')
+            .desc("[Optional - Enterprise Edition only] passive backup member nodes for context")
+            .build();
     /**
      * Comma separated list of Axon Server node names as messaging-only nodes for the context.
      */
-    public static final Option MESSAGING_ONLY_NODES = Option.builder("m")
-                                                            .hasArgs()
-                                                            .valueSeparator(',')
-                                                            .longOpt("messaging-only").desc(
-                    "[Optional - Enterprise Edition only] messaging-only member nodes for context").build();
+    public static final Option MESSAGING_ONLY_NODES = Option
+            .builder("m")
+            .hasArgs()
+            .valueSeparator(',')
+            .longOpt("messaging-only")
+            .desc("[Optional - Enterprise Edition only] messaging-only member nodes for context")
+            .build();
     /**
      * The name of the context, where the nodes should be added to.
      */
-    public static final Option CONTEXT_TO_REGISTER_IN = Option.builder("c").longOpt("context").hasArg().desc(
-            "[Optional - Enterprise Edition only] context to register node in").build();
+    public static final Option CONTEXT_TO_REGISTER_IN = Option
+            .builder("c")
+            .longOpt("context")
+            .hasArg()
+            .desc("[Optional - Enterprise Edition only] context to register node in")
+            .build();
     /**
      * Indicator to register a node without adding it to any contexts.
      */
-    public static final Option DONT_REGISTER_IN_CONTEXTS = Option.builder().longOpt("no-contexts").desc(
-            "[Optional - Enterprise Edition only] add node to cluster, but don't register it in any contexts").build();
+    public static final Option DONT_REGISTER_IN_CONTEXTS = Option
+            .builder()
+            .longOpt("no-contexts")
+            .desc("[Optional - Enterprise Edition only] add node to cluster, but don't register it in any contexts")
+            .build();
     /**
      * While removing a node from a context, preserve the event store to be able to add it again (with a different
      * role), without the need to
      * copy all events again.
      */
-    public static final Option PRESERVE_EVENT_STORE = Option.builder().longOpt("preserve-event-store").desc(
-            "[Optional - Enterprise Edition only] keep event store contents").build();
+    public static final Option PRESERVE_EVENT_STORE = Option
+            .builder()
+            .longOpt("preserve-event-store")
+            .desc("[Optional - Enterprise Edition only] keep event store contents")
+            .build();
     /**
      * The internal hostname of the AxonServer node to register the node to.
      */
-    public static final Option INTERNALHOST = Option.builder("h").longOpt("internal-host").desc("Internal hostname of the node").required().hasArg().build();
+    public static final Option INTERNALHOST = Option
+            .builder("h")
+            .longOpt("internal-host")
+            .hasArg()
+            .required()
+            .desc("Internal hostname of the node")
+            .build();
     /**
      * The internal gRPC port number of the Axon Server to to register the node to.
      */
-    public static final Option INTERNALPORT = Option.builder("p").longOpt("internal-port").desc("Internal port of the node (default 8224)").type(PatternOptionBuilder.NUMBER_VALUE).hasArg().build();
+    public static final Option INTERNALPORT = Option
+            .builder("p")
+            .longOpt("internal-port")
+            .hasArg()
+            .type(PatternOptionBuilder.NUMBER_VALUE)
+            .desc("Internal port of the node (default 8224)")
+            .build();
     /**
      * Token to use when sending CLI commands.
      */
-    public static final Option TOKEN = Option.builder("t").longOpt("access-token").desc("[Optional] Access token to authenticate at server").hasArg().build();
+    public static final Option TOKEN = Option
+            .builder("t")
+            .longOpt("access-token")
+            .hasArg()
+            .desc("[Optional] Access token to authenticate at server")
+            .build();
     /**
      * The username for the user to manage.
      */
-    public static final Option USERNAME = Option.builder("u").longOpt("username").required().desc("Username").hasArg().build();
+    public static final Option USERNAME = Option
+            .builder("u")
+            .longOpt("username")
+            .hasArg()
+            .required()
+            .desc("Username")
+            .build();
     /**
      * The password for the user to create.
      */
-    public static final Option PASSWORD = Option.builder("p").longOpt("password").desc("[Optional] Password for the user").hasArg().build();
+    public static final Option PASSWORD = Option
+            .builder("p")
+            .longOpt("password")
+            .hasArg()
+            .desc("[Optional] Password for the user")
+            .build();
     /**
      * Defines the token for a new application. If this is omitted Axon Server will generate a token.
      */
-    public static final Option SET_TOKEN = Option.builder("T").longOpt("token").desc("use this token for the app").hasArg().build();
+    public static final Option SET_TOKEN = Option
+            .builder("T")
+            .longOpt("token")
+            .hasArg()
+            .desc("use this token for the app")
+            .build();
     /**
      * Output format for the command (text or json).
      */
-    public static final Option OUTPUT = Option.builder("o").hasArg().longOpt("output").desc("Output format (txt,json)").build();
+    public static final Option OUTPUT = Option
+            .builder("o")
+            .longOpt("output")
+            .hasArg()
+            .desc("Output format (txt,json)")
+            .build();
 }


### PR DESCRIPTION
Added two options and reversed default behaviour:
- Default behaviour was to ignore certificate problems, now the default is to do strict checking.
- Added option "-s" as a shorthand for "-S https://localhost:8024".
- Added option "-i" to install the trust policy that accepts any certificate, and disables hostname verification.