### PR TITLE
Cleanup query handler/command handler classes

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/applicationevents/SubscriptionQueryEvents.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/applicationevents/SubscriptionQueryEvents.java
@@ -56,17 +56,20 @@ public class SubscriptionQueryEvents {
             return context;
         }
 
-        public SubscriptionQuery subscriptionQuery(){
-            switch (request.getRequestCase()){
-                case SUBSCRIBE: return request.getSubscribe();
-                case GET_INITIAL_RESULT: return request.getGetInitialResult();
-                case UNSUBSCRIBE: return request.getUnsubscribe();
+        public SubscriptionQuery subscriptionQuery() {
+            switch (request.getRequestCase()) {
+                case SUBSCRIBE:
+                    return request.getSubscribe();
+                case GET_INITIAL_RESULT:
+                    return request.getGetInitialResult();
+                case UNSUBSCRIBE:
+                    return request.getUnsubscribe();
             }
             return null;
         }
 
-        public boolean isSubscription() {
-            return !request.getRequestCase().equals(UNSUBSCRIBE);
+        public boolean isUnsubscribe() {
+            return request.getRequestCase().equals(UNSUBSCRIBE);
         }
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/applicationevents/TopologyEvents.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/applicationevents/TopologyEvents.java
@@ -9,6 +9,7 @@
 
 package io.axoniq.axonserver.applicationevents;
 
+import io.axoniq.axonserver.grpc.PlatformService;
 import io.axoniq.axonserver.message.ClientIdentification;
 
 /**
@@ -18,168 +19,129 @@ import io.axoniq.axonserver.message.ClientIdentification;
 public class TopologyEvents {
 
     public abstract static class TopologyBaseEvent {
-        private final boolean forwarded;
 
-        protected TopologyBaseEvent(boolean forwarded) {
-            this.forwarded = forwarded;
+        private final boolean proxied;
+
+        protected TopologyBaseEvent(boolean proxied) {
+            this.proxied = proxied;
         }
 
-        public boolean isForwarded() {
-            return forwarded;
+        public boolean isProxied() {
+            return proxied;
         }
-
     }
 
-    public static class ApplicationConnected extends TopologyBaseEvent {
-        private final String context;
+    public abstract static class ApplicationBaseEvent extends TopologyBaseEvent {
+
+        private final ClientIdentification client;
+
+        protected ApplicationBaseEvent(ClientIdentification client, boolean proxied) {
+            super(proxied);
+            this.client = client;
+        }
+
+        public String getClient() {
+            return client.getClient();
+        }
+
+        public String getContext() {
+            return client.getContext();
+        }
+
+        public ClientIdentification clientIdentification() {
+            return client;
+        }
+    }
+
+    public static class ApplicationConnected extends ApplicationBaseEvent {
+
         private final String componentName;
-        private final String client;
         private final String proxy;
+
+        public ApplicationConnected(ClientIdentification client, String componentName, String proxy) {
+            super(client, proxy != null);
+            this.componentName = componentName;
+            this.proxy = proxy;
+        }
+
+        public ApplicationConnected(PlatformService.ClientComponent clientComponent) {
+            this(new ClientIdentification(clientComponent.getContext(), clientComponent.getClient()),
+                 clientComponent.getComponent());
+        }
 
         public ApplicationConnected(String context, String componentName, String client, String proxy) {
-            super(proxy != null);
-            this.context = context;
-            this.componentName = componentName;
-            this.client = client;
-            this.proxy = proxy;
+            this(new ClientIdentification(context, client), componentName, proxy);
         }
-        public ApplicationConnected(String context, String componentName, String client) {
-            this(context, componentName, client, null);
+
+        public ApplicationConnected(ClientIdentification client, String componentName) {
+            this(client, componentName, null);
         }
 
         public String getComponentName() {
             return componentName;
         }
 
-        public String getClient() {
-            return client;
-        }
-
-        public String getContext() {
-            return context;
-        }
 
         public String getProxy() {
             return proxy;
         }
-
-        public boolean isProxied() {
-            return isForwarded();
-        }
-
-        public ClientIdentification clientIdentification() {
-            return new ClientIdentification(context, client);
-        }
     }
 
-    public static class ApplicationDisconnected extends TopologyBaseEvent {
-        private final String context;
+    public static class ApplicationDisconnected extends ApplicationBaseEvent {
+
         private final String componentName;
-        private final String client;
         private final String proxy;
 
-        public ApplicationDisconnected(String context, String componentName, String client, String proxy) {
-            super(proxy != null);
-            this.context = context;
+        public ApplicationDisconnected(ClientIdentification client, String componentName, String proxy) {
+            super(client, proxy != null);
             this.componentName = componentName;
-            this.client = client;
             this.proxy = proxy;
         }
 
-        public ApplicationDisconnected(String context,
-                                       String componentName, String client
+        public ApplicationDisconnected(ClientIdentification client,
+                                       String componentName
         ) {
-            this(context, componentName, client, null);
+            this(client, componentName, null);
+        }
+
+        public ApplicationDisconnected(String context, String componentName, String client, String proxy) {
+            this(new ClientIdentification(context, client), componentName, proxy);
+        }
+
+        public ApplicationDisconnected(PlatformService.ClientComponent clientComponent) {
+            this(new ClientIdentification(clientComponent.getContext(), clientComponent.getClient()),
+                 clientComponent.getComponent());
         }
 
         public String getComponentName() {
             return componentName;
         }
 
-        public String getClient() {
-            return client;
-        }
-
-        public String getContext() {
-            return context;
-        }
-
         public String getProxy() {
             return proxy;
         }
 
-        public boolean isProxied() {
-            return isForwarded();
-        }
-
-        public ClientIdentification clientIdentification() {
-            return new ClientIdentification(context, client);
-        }
-
     }
 
-    public static class CommandHandlerDisconnected extends TopologyBaseEvent {
-        private final String context;
-        private final String client;
+    public static class CommandHandlerDisconnected extends ApplicationBaseEvent {
 
-        public CommandHandlerDisconnected(String context, String client, boolean proxied) {
-            super(proxied);
-            this.context = context;
-            this.client = client;
+        public CommandHandlerDisconnected(ClientIdentification client, boolean proxied) {
+            super(client, proxied);
         }
 
-        public CommandHandlerDisconnected(String context, String client
-        ) {
-            this(context, client, false);
-        }
-
-        public String getClient() {
-            return client;
-        }
-
-        public String getContext() {
-            return context;
-        }
-
-        public boolean isProxied() {
-            return isForwarded();
-        }
-
-        public ClientIdentification clientIdentification() {
-            return new ClientIdentification(context, client);
+        public CommandHandlerDisconnected(ClientIdentification client) {
+            this(client, false);
         }
     }
 
-    public static class QueryHandlerDisconnected extends TopologyBaseEvent {
+    public static class QueryHandlerDisconnected extends ApplicationBaseEvent {
 
-        private final String context;
-        private final String client;
-
-        public QueryHandlerDisconnected(String context, String client, boolean proxied) {
-            super(proxied);
-            this.context = context;
-            this.client = client;
+        public QueryHandlerDisconnected(ClientIdentification client, boolean proxied) {
+            super(client, proxied);
         }
 
-        public QueryHandlerDisconnected(String context, String client
-        ) {
-            this(context, client, false);
-        }
-
-        public String getClient() {
-            return client;
-        }
-
-        public String getContext() {
-            return context;
-        }
-
-        public boolean isProxied() {
-            return isForwarded();
-        }
-
-        public ClientIdentification clientIdentification() {
-            return new ClientIdentification(context, client);
+        public QueryHandlerDisconnected(ClientIdentification client) {
+            this(client, false);
         }
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/instance/Client.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/instance/Client.java
@@ -36,4 +36,6 @@ public interface Client extends Printable, ComponentItem {
     default void printOn(Media media) {
         media.with("name", name());
     }
+
+    String componentName();
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/instance/Client.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/instance/Client.java
@@ -23,8 +23,12 @@ public interface Client extends Printable, ComponentItem {
 
     String context();
 
+    default String axonServerNode() {
+        return null;
+    }
+
     @Override
-    default boolean belongsToContext(String context){
+    default boolean belongsToContext(String context) {
         return context.equals(context());
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/instance/GenericClient.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/instance/GenericClient.java
@@ -42,6 +42,11 @@ public class GenericClient implements Client {
     }
 
     @Override
+    public String axonServerNode() {
+        return axonServerNode;
+    }
+
+    @Override
     public Boolean belongsToComponent(String component) {
         return component.equals(componentName);
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/instance/GenericClient.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/instance/GenericClient.java
@@ -42,6 +42,11 @@ public class GenericClient implements Client {
     }
 
     @Override
+    public String componentName() {
+        return componentName;
+    }
+
+    @Override
     public String axonServerNode() {
         return axonServerNode;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/CommandService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/CommandService.java
@@ -199,8 +199,7 @@ public class CommandService implements AxonServerClientService {
 
             private void checkInitClient(String clientId, String component) {
                 clientRef.compareAndSet(null, new ClientIdentification(context, clientId));
-                commandHandlerRef.compareAndSet(null, new DirectCommandHandler(wrappedResponseObserver,
-                                                                               clientRef.get(), component,
+                commandHandlerRef.compareAndSet(null, new DirectCommandHandler(clientRef.get(), component,
                                                                                commandQueues));
             }
 
@@ -221,8 +220,7 @@ public class CommandService implements AxonServerClientService {
                 if (clientRef.get() != null) {
                     commandDispatcher.cleanupRegistrations(clientRef.get());
                     commandQueues.move(clientRef.get().toString(), commandDispatcher::redispatch);
-                    eventPublisher.publishEvent(new CommandHandlerDisconnected(clientRef.get().getContext(),
-                                                                               clientRef.get().getClient()));
+                    eventPublisher.publishEvent(new CommandHandlerDisconnected(clientRef.get()));
                 }
                 GrpcCommandDispatcherListener listener = listenerRef.get();
                 if (listener != null) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcQueryDispatcherListener.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/GrpcQueryDispatcherListener.java
@@ -10,6 +10,7 @@
 package io.axoniq.axonserver.grpc;
 
 import io.axoniq.axonserver.grpc.query.QueryProviderInbound;
+import io.axoniq.axonserver.message.FlowControlQueues;
 import io.axoniq.axonserver.message.query.QueryDispatcher;
 import io.axoniq.axonserver.message.query.WrappedQuery;
 import io.grpc.stub.StreamObserver;
@@ -19,24 +20,34 @@ import org.slf4j.LoggerFactory;
 /**
  * Reads messages for a specific client from a queue and sends them to the client using gRPC.
  * Only reads messages when there are permits left.
+ *
  * @author Marc Gathier
  */
-public class GrpcQueryDispatcherListener extends GrpcFlowControlledDispatcherListener<QueryProviderInbound,WrappedQuery> implements QueryRequestValidator {
+public class GrpcQueryDispatcherListener
+        extends GrpcFlowControlledDispatcherListener<QueryProviderInbound, WrappedQuery>
+        implements QueryRequestValidator {
+
     private static final Logger logger = LoggerFactory.getLogger(GrpcQueryDispatcherListener.class);
     private final QueryDispatcher queryDispatcher;
 
-    public GrpcQueryDispatcherListener(QueryDispatcher queryDispatcher, String client, StreamObserver<QueryProviderInbound> queryProviderInboundStreamObserver, int threads) {
-        super(queryDispatcher.getQueryQueue(), client, queryProviderInboundStreamObserver, threads);
+    public GrpcQueryDispatcherListener(QueryDispatcher queryDispatcher,
+                                       FlowControlQueues<WrappedQuery> queryQueue,
+                                       String client,
+                                       StreamObserver<QueryProviderInbound> queryProviderInboundStreamObserver,
+                                       int threads) {
+        super(queryQueue, client, queryProviderInboundStreamObserver, threads);
         this.queryDispatcher = queryDispatcher;
     }
 
     @Override
     protected boolean send(WrappedQuery message) {
-        if( logger.isDebugEnabled()) {
-            logger.debug("Send request {}, with priority: {}", message.queryRequest(), message.priority() );
+        if (logger.isDebugEnabled()) {
+            logger.debug("Send request {}, with priority: {}", message.queryRequest(), message.priority());
         }
         SerializedQuery request = validate(message, queryDispatcher, logger);
-        if( request == null) return false;
+        if (request == null) {
+            return false;
+        }
         inboundStream.onNext(QueryProviderInbound.newBuilder().setQuery(request.query()).build());
         return true;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/PlatformService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/PlatformService.java
@@ -330,9 +330,7 @@ public class PlatformService extends PlatformServiceGrpc.PlatformServiceImplBase
         logger.debug("Registered client : {}", clientComponent);
 
         connectionMap.put(clientComponent, responseObserver);
-        eventPublisher.publishEvent(new TopologyEvents.ApplicationConnected(
-                clientComponent.context, clientComponent.component, clientComponent.client
-        ));
+        eventPublisher.publishEvent(new TopologyEvents.ApplicationConnected(clientComponent));
     }
 
     private void deregisterClient(ClientComponent clientComponent) {
@@ -340,9 +338,7 @@ public class PlatformService extends PlatformServiceGrpc.PlatformServiceImplBase
 
         if (clientComponent != null) {
             connectionMap.remove(clientComponent);
-            eventPublisher.publishEvent(new TopologyEvents.ApplicationDisconnected(
-                    clientComponent.context, clientComponent.component, clientComponent.client, null
-            ));
+            eventPublisher.publishEvent(new TopologyEvents.ApplicationDisconnected(clientComponent));
         }
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/grpc/QueryService.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/grpc/QueryService.java
@@ -212,7 +212,7 @@ public class QueryService extends QueryServiceGrpc.QueryServiceImplBase implemen
 
             private void cleanup() {
                 if (client.get() != null) {
-                    eventPublisher.publishEvent(new QueryHandlerDisconnected(context, client.get().getClient()));
+                    eventPublisher.publishEvent(new QueryHandlerDisconnected(client.get()));
                 }
                 if (listener.get() != null) {
                     dispatcherListeners.remove(client.get());

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandDispatcher.java
@@ -174,7 +174,7 @@ public class CommandDispatcher {
                                                                                         .getResponseConsumer(),
                                                                                 client.getClient(),
                                                                                 client.getComponentName()));
-        return client.queueName();
+        return client.getClient().toString();
     }
 
     private void handlePendingCommands(ClientIdentification client) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandHandler.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandHandler.java
@@ -11,20 +11,18 @@ package io.axoniq.axonserver.message.command;
 
 import io.axoniq.axonserver.grpc.SerializedCommand;
 import io.axoniq.axonserver.message.ClientIdentification;
-import io.grpc.stub.StreamObserver;
 
 import java.util.Objects;
 
 /**
  * @author Marc Gathier
  */
-public abstract class CommandHandler<T> implements Comparable<CommandHandler<T>> {
-    protected final StreamObserver<T> observer;
+public abstract class CommandHandler implements Comparable<CommandHandler> {
+
     protected final ClientIdentification client;
     protected final String componentName;
 
-    public CommandHandler(StreamObserver<T> responseObserver, ClientIdentification client, String componentName) {
-        this.observer = responseObserver;
+    public CommandHandler(ClientIdentification client, String componentName) {
         this.client = client;
         this.componentName = componentName;
     }
@@ -39,24 +37,24 @@ public abstract class CommandHandler<T> implements Comparable<CommandHandler<T>>
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CommandHandler<?> that = (CommandHandler<?>) o;
-        return Objects.equals(observer, that.observer) &&
-                Objects.equals(client, that.client);
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CommandHandler that = (CommandHandler) o;
+        return Objects.equals(client, that.client);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(observer, client);
+        return Objects.hash(client);
     }
 
     @Override
     public int compareTo(CommandHandler o) {
         int clientResult = client.compareTo(o.client);
-        if( clientResult == 0) {
-            clientResult = observer.toString().compareTo(o.observer.toString());
-        }
         return clientResult;
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandHandler.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandHandler.java
@@ -54,17 +54,12 @@ public abstract class CommandHandler implements Comparable<CommandHandler> {
 
     @Override
     public int compareTo(CommandHandler o) {
-        int clientResult = client.compareTo(o.client);
-        return clientResult;
+        return client.compareTo(o.client);
     }
 
     public abstract void dispatch( SerializedCommand request);
 
-    public String queueName() {
-        return client.toString();
-    }
-
-    public String getMessagingServerName() {
+    public String axonServerName() {
         return null;
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandHandler.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandHandler.java
@@ -62,8 +62,6 @@ public abstract class CommandHandler<T> implements Comparable<CommandHandler<T>>
 
     public abstract void dispatch( SerializedCommand request);
 
-    public abstract void confirm( String messageId);
-
     public String queueName() {
         return client.toString();
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/DirectCommandHandler.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/DirectCommandHandler.java
@@ -29,6 +29,6 @@ public class DirectCommandHandler extends CommandHandler {
 
     @Override
     public void dispatch(SerializedCommand request) {
-        commandQueues.put(queueName(), new WrappedCommand(client, request));
+        commandQueues.put(client.toString(), new WrappedCommand(client, request));
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/DirectCommandHandler.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/DirectCommandHandler.java
@@ -10,22 +10,20 @@
 package io.axoniq.axonserver.message.command;
 
 import io.axoniq.axonserver.grpc.SerializedCommand;
-import io.axoniq.axonserver.grpc.SerializedCommandProviderInbound;
 import io.axoniq.axonserver.message.ClientIdentification;
 import io.axoniq.axonserver.message.FlowControlQueues;
-import io.grpc.stub.StreamObserver;
 
 /**
  * @author Marc Gathier
  */
-public class DirectCommandHandler extends CommandHandler<SerializedCommandProviderInbound> {
+public class DirectCommandHandler extends CommandHandler {
 
     private final FlowControlQueues<WrappedCommand> commandQueues;
 
-    public DirectCommandHandler(StreamObserver<SerializedCommandProviderInbound> responseObserver,
-                                ClientIdentification client, String componentName,
+    public DirectCommandHandler(ClientIdentification client,
+                                String componentName,
                                 FlowControlQueues<WrappedCommand> commandQueues) {
-        super(responseObserver, client, componentName);
+        super(client, componentName);
         this.commandQueues = commandQueues;
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/DirectQueryHandler.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/DirectQueryHandler.java
@@ -17,10 +17,14 @@ import io.grpc.stub.StreamObserver;
 /**
  * @author Marc Gathier
  */
-public class DirectQueryHandler extends QueryHandler<QueryProviderInbound> {
+public class DirectQueryHandler extends QueryHandler {
 
-    public DirectQueryHandler(StreamObserver<QueryProviderInbound> streamObserver, ClientIdentification clientIdentification, String componentName) {
-        super(streamObserver, clientIdentification, componentName);
+    private final StreamObserver<QueryProviderInbound> streamObserver;
+
+    public DirectQueryHandler(StreamObserver<QueryProviderInbound> streamObserver,
+                              ClientIdentification clientIdentification, String componentName) {
+        super(clientIdentification, componentName);
+        this.streamObserver = streamObserver;
     }
 
     @Override

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryHandler.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryHandler.java
@@ -14,23 +14,22 @@ import io.axoniq.axonserver.grpc.SerializedQuery;
 import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
 import io.axoniq.axonserver.message.ClientIdentification;
 import io.axoniq.axonserver.message.FlowControlQueues;
-import io.grpc.stub.StreamObserver;
 
 import java.util.Objects;
 
 /**
  * Basic handler for queries. Puts a query in a specific queue to send it based on its priority to the target client.
+ *
  * @author Marc Gathier
  * @since 4.0
  */
-public abstract class QueryHandler<T>  {
+public abstract class QueryHandler {
+
     private final ClientIdentification client;
     private final String componentName;
-    protected final StreamObserver<T> streamObserver;
 
-    protected QueryHandler(StreamObserver<T> streamObserver, ClientIdentification client, String componentName) {
+    protected QueryHandler(ClientIdentification client, String componentName) {
         this.client = client;
-        this.streamObserver = streamObserver;
         this.componentName = componentName;
     }
 
@@ -74,7 +73,7 @@ public abstract class QueryHandler<T>  {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        QueryHandler<?> that = (QueryHandler<?>) o;
+        QueryHandler that = (QueryHandler) o;
         return Objects.equals(client, that.client);
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryHandler.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryHandler.java
@@ -13,7 +13,6 @@ package io.axoniq.axonserver.message.query;
 import io.axoniq.axonserver.grpc.SerializedQuery;
 import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
 import io.axoniq.axonserver.message.ClientIdentification;
-import io.axoniq.axonserver.message.FlowControlQueues;
 
 import java.util.Objects;
 
@@ -47,23 +46,19 @@ public abstract class QueryHandler {
         return componentName;
     }
 
-    public String queueName() {
-        return client.toString();
-    }
-
     public String toString() {
         return client.toString();
     }
 
     /**
      * Enqueues a query for the target client. Queries will be read from queues based on priorities.
-     * @param request the query to send
+     *
+     * @param request    the query to send
      * @param queryQueue the queue holders for queries
-     * @param timeout timeout of the query
+     * @param timeout    timeout of the query
      */
-    public void enqueue(SerializedQuery request, FlowControlQueues<WrappedQuery> queryQueue, long timeout) {
-        queryQueue.put(queueName(), new WrappedQuery(request.withClient(getClientId()), timeout));
-    }
+    public abstract void dispatch(SerializedQuery request, long timeout);
+
 
     @Override
     public boolean equals(Object o) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/QueryUpdateDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/QueryUpdateDispatcher.java
@@ -35,10 +35,10 @@ public class QueryUpdateDispatcher {
     @EventListener
     public void on(ProxiedSubscriptionQueryRequest event) {
         String subscriptionId = event.subscriptionQuery().getSubscriptionIdentifier();
-        if (event.isSubscription()) {
-            handlers.put(subscriptionId, event.handler());
-        } else {
+        if (event.isUnsubscribe()) {
             handlers.remove(subscriptionId);
+        } else {
+            handlers.put(subscriptionId, event.handler());
         }
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/metric/BaseMetricName.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/metric/BaseMetricName.java
@@ -48,7 +48,11 @@ public enum BaseMetricName implements MetricName {
     /**
      * Metric for the rate of events stored (tags: context)
      */
-    AXON_EVENTS("axon.event", "Number of event stored per second"),
+    AXON_EVENTS("axon.event", "Number of event stored"),
+    /**
+     * Metric for the rate of events stored (tags: context)
+     */
+    AXON_AGGREGATE_READS("axon.aggregate.reads", "Number of aggregates read"),
     /**
      * Metric for the rate of snapshots stored (tags: context)
      */

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/CommandRestController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/CommandRestController.java
@@ -156,7 +156,7 @@ public class CommandRestController {
             CommandHandler commandHandler = entry.getKey();
             jsonCommandMapping.client = commandHandler.getClient().toString();
             jsonCommandMapping.component = commandHandler.getComponentName();
-            jsonCommandMapping.proxy = commandHandler.getMessagingServerName();
+            jsonCommandMapping.proxy = commandHandler.axonServerName();
 
             jsonCommandMapping.commands = entry.getValue().stream().map(e -> e.getCommand()).collect(Collectors.toSet());
             return jsonCommandMapping;

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/CommandRestController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/CommandRestController.java
@@ -12,6 +12,7 @@ package io.axoniq.axonserver.rest;
 import io.axoniq.axonserver.component.ComponentItems;
 import io.axoniq.axonserver.component.command.ComponentCommand;
 import io.axoniq.axonserver.component.command.DefaultCommands;
+import io.axoniq.axonserver.grpc.CommandService;
 import io.axoniq.axonserver.grpc.SerializedCommand;
 import io.axoniq.axonserver.logging.AuditLog;
 import io.axoniq.axonserver.message.command.CommandDispatcher;
@@ -60,18 +61,26 @@ public class CommandRestController {
 
     private final CommandDispatcher commandDispatcher;
     private final CommandRegistrationCache registrationCache;
+    private final CommandService commandService;
 
 
-    public CommandRestController(CommandDispatcher commandDispatcher, CommandRegistrationCache registrationCache) {
+    public CommandRestController(CommandDispatcher commandDispatcher, CommandRegistrationCache registrationCache,
+                                 CommandService commandService) {
         this.commandDispatcher = commandDispatcher;
         this.registrationCache = registrationCache;
+        this.commandService = commandService;
     }
 
     @GetMapping("/components/{component}/commands")
-    public Iterable<ComponentCommand> getByComponent(@PathVariable("component") String component, @RequestParam("context") String context, Principal principal){
-        auditLog.info("[{}] Request to list all Commands for which component \"{}\" in context \"{}\" has a registered handler.", AuditLog.username(principal), component, context);
+    public Iterable<ComponentCommand> getByComponent(@PathVariable("component") String component,
+                                                     @RequestParam("context") String context, Principal principal) {
+        auditLog.info(
+                "[{}] Request to list all Commands for which component \"{}\" in context \"{}\" has a registered handler.",
+                AuditLog.username(principal),
+                component,
+                context);
 
-        return new ComponentItems<>(component, context, new DefaultCommands( registrationCache));
+        return new ComponentItems<>(component, context, new DefaultCommands(registrationCache));
     }
 
     @GetMapping("commands")
@@ -99,7 +108,8 @@ public class CommandRestController {
     public List<JsonQueueInfo> queues(Principal principal) {
         auditLog.info("[{}] Request to list all CommandQueues.", AuditLog.username(principal));
 
-        return commandDispatcher.getCommandQueues().getSegments().entrySet().stream().map(JsonQueueInfo::from).collect(Collectors.toList());
+        return commandService.getCommandQueues().getSegments().entrySet().stream().map(JsonQueueInfo::from).collect(
+                Collectors.toList());
     }
 
     @GetMapping("commands/count")

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/command/DefaultCommandTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/command/DefaultCommandTest.java
@@ -30,12 +30,12 @@ public class DefaultCommandTest {
 
     @Before
     public void setUp() throws Exception {
-        ImmutableSet<CommandHandler> commandHandlers = ImmutableSet.of(new DirectCommandHandler(null,
-                                                                                                new ClientIdentification(
-                                                                                                        Topology.DEFAULT_CONTEXT,
-                                                                                                        "client"),
-                                                                                                "componentA",
-                                                                                                null));
+        ImmutableSet<CommandHandler> commandHandlers = ImmutableSet
+                .of(new DirectCommandHandler(new ClientIdentification(
+                        Topology.DEFAULT_CONTEXT,
+                        "client"),
+                                             "componentA",
+                                             null));
         defaultCommand = new DefaultCommand(new CommandRegistrationCache.RegistrationEntry(Topology.DEFAULT_CONTEXT,
                                                                                            "commandName"), commandHandlers);
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/command/DefaultCommandTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/command/DefaultCommandTest.java
@@ -31,7 +31,11 @@ public class DefaultCommandTest {
     @Before
     public void setUp() throws Exception {
         ImmutableSet<CommandHandler> commandHandlers = ImmutableSet.of(new DirectCommandHandler(null,
-                                                                                                new ClientIdentification(Topology.DEFAULT_CONTEXT,"client"), "componentA"));
+                                                                                                new ClientIdentification(
+                                                                                                        Topology.DEFAULT_CONTEXT,
+                                                                                                        "client"),
+                                                                                                "componentA",
+                                                                                                null));
         defaultCommand = new DefaultCommand(new CommandRegistrationCache.RegistrationEntry(Topology.DEFAULT_CONTEXT,
                                                                                            "commandName"), commandHandlers);
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/instance/FakeClient.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/instance/FakeClient.java
@@ -42,6 +42,11 @@ public class FakeClient implements Client {
     }
 
     @Override
+    public String componentName() {
+        return "";
+    }
+
+    @Override
     public Boolean belongsToComponent(String component) {
         return belongs;
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/query/DefaultQueryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/query/DefaultQueryTest.java
@@ -10,7 +10,7 @@
 package io.axoniq.axonserver.component.query;
 
 import com.google.common.collect.ImmutableSet;
-import io.axoniq.axonserver.message.query.DirectQueryHandler;
+import io.axoniq.axonserver.message.query.FakeQueryHandler;
 import io.axoniq.axonserver.message.query.QueryDefinition;
 import io.axoniq.axonserver.message.query.QueryHandler;
 import io.axoniq.axonserver.serializer.GsonMedia;
@@ -35,8 +35,8 @@ public class DefaultQueryTest {
     public void setUp() throws Exception {
         QueryDefinition queryDefinition = new QueryDefinition("context", "queryName");
         Map<String, Set<QueryHandler>> handlers = new HashMap<>();
-        handlers.put("componentA", ImmutableSet.of(new DirectQueryHandler(null, null, null),
-                                                   new DirectQueryHandler(null, null, null)));
+        handlers.put("componentA", ImmutableSet.of(new FakeQueryHandler(null, null),
+                                                   new FakeQueryHandler(null, null)));
         handlers.put("componentB", ImmutableSet.of());
         handlers.put("componentC", null);
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/version/ClientVersionsCacheTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/version/ClientVersionsCacheTest.java
@@ -28,7 +28,7 @@ public class ClientVersionsCacheTest {
         assertEquals("4.2.3", testSubject.apply(new ClientIdentification("context2", "D")));
         assertEquals("4.2.3", testSubject.apply(new ClientIdentification("context2", "E")));
 
-        testSubject.on(new TopologyEvents.ApplicationDisconnected("context2", "componentName", "E"));
+        testSubject.on(new TopologyEvents.ApplicationDisconnected("context2", "componentName", "E", null));
         assertNull(testSubject.apply(new ClientIdentification("E", "context2")));
     }
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/CommandServiceTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/CommandServiceTest.java
@@ -51,7 +51,7 @@ public class CommandServiceTest {
         commandQueue = new FlowControlQueues<>();
         eventPublisher = mock(ApplicationEventPublisher.class);
 
-        when(commandDispatcher.getCommandQueues()).thenReturn(commandQueue);
+//        when(commandDispatcher.getCommandQueues()).thenReturn(commandQueue);
         //when(commandDispatcher.redispatch(any(WrappedCommand.class))).thenReturn("test");
         MessagingPlatformConfiguration configuration = new MessagingPlatformConfiguration(new TestSystemInfoProvider());
         Topology topology = new DefaultTopology(configuration);

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/PlatformServiceTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/PlatformServiceTest.java
@@ -29,7 +29,6 @@ import org.mockito.runners.*;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -227,7 +226,10 @@ public class PlatformServiceTest {
                                                                                                      .setComponentName("component")
         ).build());
         assertEquals(1, platformService.getConnectedClients().size());
-        platformService.on(new TopologyEvents.ApplicationDisconnected(Topology.DEFAULT_CONTEXT, "component", "Release"));
+        platformService.on(new TopologyEvents.ApplicationDisconnected(Topology.DEFAULT_CONTEXT,
+                                                                      "component",
+                                                                      "Release",
+                                                                      null));
         assertEquals(0, platformService.getConnectedClients().size());
         assertTrue(responseObserver.completed);
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/heartbeat/HeartbeatMonitorTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/heartbeat/HeartbeatMonitorTest.java
@@ -30,13 +30,13 @@ public class HeartbeatMonitorTest {
     private final ApplicationConnected client4_2_1Connected =
             new ApplicationConnected("A", "A", "A", "4.2.1");
     private final ApplicationDisconnected client4_2_1Disconnected =
-            new ApplicationDisconnected("A", "A", "A");
+            new ApplicationDisconnected("A", "A", "A", null);
 
     private final ClientIdentification client4_2 = new ClientIdentification("B", "B");
     private final ApplicationConnected client4_2Connected =
             new ApplicationConnected("B", "B", "B", "4.2");
     private final ApplicationDisconnected client4_2Disconnected =
-            new ApplicationDisconnected("B", "B", "B");
+            new ApplicationDisconnected("B", "B", "B", null);
 
     private final PlatformInboundInstruction heartbeat = newBuilder().setHeartbeat(Heartbeat.newBuilder()).build();
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandRegistrationCacheLoadFactorTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandRegistrationCacheLoadFactorTest.java
@@ -108,10 +108,5 @@ public class CommandRegistrationCacheLoadFactorTest {
         public void dispatch(SerializedCommand request) {
 
         }
-
-        @Override
-        public void confirm(String messageId) {
-
-        }
     }
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandRegistrationCacheLoadFactorTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandRegistrationCacheLoadFactorTest.java
@@ -2,11 +2,9 @@ package io.axoniq.axonserver.message.command;
 
 import io.axoniq.axonserver.applicationevents.SubscriptionEvents.SubscribeCommand;
 import io.axoniq.axonserver.grpc.SerializedCommand;
-import io.axoniq.axonserver.grpc.SerializedCommandProviderInbound;
 import io.axoniq.axonserver.grpc.command.Command;
 import io.axoniq.axonserver.grpc.command.CommandSubscription;
 import io.axoniq.axonserver.message.ClientIdentification;
-import io.axoniq.axonserver.util.FakeStreamObserver;
 import org.junit.*;
 
 import java.util.HashMap;
@@ -96,11 +94,10 @@ public class CommandRegistrationCacheLoadFactorTest {
     }
 
 
-    private static class FakeCommandHandler extends CommandHandler<SerializedCommandProviderInbound> {
+    private static class FakeCommandHandler extends CommandHandler {
 
         public FakeCommandHandler(String clientId) {
-            super(new FakeStreamObserver<>(),
-                  new ClientIdentification("context", clientId),
+            super(new ClientIdentification("context", clientId),
                   "componentName");
         }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
@@ -133,7 +133,10 @@ public class EventDispatcherTest {
         inputStream.onNext(GetEventsRequest.newBuilder().setClientId("sampleClient").build());
         assertEquals(1, responseObserver.count);
         assertTrue(responseObserver.completed);
-        testSubject.on(new TopologyEvents.ApplicationDisconnected(Topology.DEFAULT_CONTEXT, "myComponent", "sampleClient"));
+        testSubject.on(new TopologyEvents.ApplicationDisconnected(Topology.DEFAULT_CONTEXT,
+                                                                  "myComponent",
+                                                                  "sampleClient",
+                                                                  null));
         assertTrue(testSubject.eventTrackerStatus(Topology.DEFAULT_CONTEXT).isEmpty());
     }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/FakeQueryHandler.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/FakeQueryHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017-2020 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.message.query;
+
+import io.axoniq.axonserver.grpc.SerializedQuery;
+import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
+import io.axoniq.axonserver.message.ClientIdentification;
+
+/**
+ * @author Marc Gathier
+ */
+public class FakeQueryHandler extends QueryHandler {
+
+    public FakeQueryHandler(ClientIdentification client, String componentName) {
+        super(client, componentName);
+    }
+
+    @Override
+    public void dispatch(SubscriptionQueryRequest query) {
+
+    }
+
+    @Override
+    public void dispatch(SerializedQuery request, long timeout) {
+
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcherTest.java
@@ -16,7 +16,7 @@ import io.axoniq.axonserver.grpc.query.QuerySubscription;
 import io.axoniq.axonserver.grpc.query.SubscriptionQuery;
 import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
 import io.axoniq.axonserver.message.ClientIdentification;
-import io.axoniq.axonserver.message.query.QueryHandler;
+import io.axoniq.axonserver.message.query.FakeQueryHandler;
 import io.axoniq.axonserver.message.query.QueryRegistrationCache;
 import org.junit.*;
 
@@ -57,7 +57,7 @@ public class SubscriptionQueryDispatcherTest {
                 new SubscriptionEvents.SubscribeQuery("Demo",
                                                       QuerySubscription.newBuilder().setClientId("client")
                                                                        .setQuery("test").build(),
-                                                      new QueryHandler(
+                                                      new FakeQueryHandler(
                                                               new ClientIdentification("Demo", "client"),
                                                               "component") {
                                                           @Override

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/subscription/SubscriptionQueryDispatcherTest.java
@@ -11,7 +11,6 @@ package io.axoniq.axonserver.message.query.subscription;
 
 import io.axoniq.axonserver.applicationevents.SubscriptionEvents;
 import io.axoniq.axonserver.applicationevents.TopologyEvents;
-import io.axoniq.axonserver.grpc.query.QueryProviderInbound;
 import io.axoniq.axonserver.grpc.query.QueryRequest;
 import io.axoniq.axonserver.grpc.query.QuerySubscription;
 import io.axoniq.axonserver.grpc.query.SubscriptionQuery;
@@ -19,7 +18,6 @@ import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
 import io.axoniq.axonserver.message.ClientIdentification;
 import io.axoniq.axonserver.message.query.QueryHandler;
 import io.axoniq.axonserver.message.query.QueryRegistrationCache;
-import io.axoniq.axonserver.util.CountingStreamObserver;
 import org.junit.*;
 
 import java.util.ArrayList;
@@ -59,8 +57,7 @@ public class SubscriptionQueryDispatcherTest {
                 new SubscriptionEvents.SubscribeQuery("Demo",
                                                       QuerySubscription.newBuilder().setClientId("client")
                                                                        .setQuery("test").build(),
-                                                      new QueryHandler<QueryProviderInbound>(
-                                                              new CountingStreamObserver<>(),
+                                                      new QueryHandler(
                                                               new ClientIdentification("Demo", "client"),
                                                               "component") {
                                                           @Override
@@ -70,7 +67,7 @@ public class SubscriptionQueryDispatcherTest {
                                                       });
         testSubject.on(subscribeQuery);
         assertEquals(1, dispatchedSubscriptions.get());
-        testSubject.on(new TopologyEvents.ApplicationDisconnected("Demo", "component", "client"));
+        testSubject.on(new TopologyEvents.ApplicationDisconnected("Demo", "component", "client", null));
         testSubject.on(subscribeQuery);
         assertEquals(2, dispatchedSubscriptions.get());
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/CommandRestControllerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/CommandRestControllerTest.java
@@ -40,9 +40,13 @@ public class CommandRestControllerTest {
     @Before
     public void setUp() {
         CommandRegistrationCache commandRegistationCache = new CommandRegistrationCache();
-        commandRegistationCache.add("DoIt", new DirectCommandHandler(new CountingStreamObserver<>(), new ClientIdentification(Topology.DEFAULT_CONTEXT,
-                                                                     "client"), "component"));
-        testSubject = new CommandRestController(commandDispatcher, commandRegistationCache);
+        commandRegistationCache.add("DoIt",
+                                    new DirectCommandHandler(new CountingStreamObserver<>(),
+                                                             new ClientIdentification(Topology.DEFAULT_CONTEXT,
+                                                                                      "client"),
+                                                             "component",
+                                                             null));
+        testSubject = new CommandRestController(commandDispatcher, commandRegistationCache, null);
     }
 
     @Test

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/CommandRestControllerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/CommandRestControllerTest.java
@@ -17,7 +17,6 @@ import io.axoniq.axonserver.message.command.CommandRegistrationCache;
 import io.axoniq.axonserver.message.command.DirectCommandHandler;
 import io.axoniq.axonserver.serializer.GsonMedia;
 import io.axoniq.axonserver.topology.Topology;
-import io.axoniq.axonserver.util.CountingStreamObserver;
 import org.junit.*;
 import org.junit.runner.*;
 import org.mockito.*;
@@ -41,8 +40,7 @@ public class CommandRestControllerTest {
     public void setUp() {
         CommandRegistrationCache commandRegistationCache = new CommandRegistrationCache();
         commandRegistationCache.add("DoIt",
-                                    new DirectCommandHandler(new CountingStreamObserver<>(),
-                                                             new ClientIdentification(Topology.DEFAULT_CONTEXT,
+                                    new DirectCommandHandler(new ClientIdentification(Topology.DEFAULT_CONTEXT,
                                                                                       "client"),
                                                              "component",
                                                              null));

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/MetricsRestControllerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/MetricsRestControllerTest.java
@@ -10,13 +10,12 @@
 package io.axoniq.axonserver.rest;
 
 import io.axoniq.axonserver.grpc.SerializedCommand;
-import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
 import io.axoniq.axonserver.message.ClientIdentification;
 import io.axoniq.axonserver.message.command.CommandHandler;
 import io.axoniq.axonserver.message.command.CommandMetricsRegistry;
 import io.axoniq.axonserver.message.command.CommandRegistrationCache;
+import io.axoniq.axonserver.message.query.FakeQueryHandler;
 import io.axoniq.axonserver.message.query.QueryDefinition;
-import io.axoniq.axonserver.message.query.QueryHandler;
 import io.axoniq.axonserver.message.query.QueryMetricsRegistry;
 import io.axoniq.axonserver.message.query.QueryRegistrationCache;
 import io.axoniq.axonserver.message.query.RoundRobinQueryHandlerSelector;
@@ -65,12 +64,7 @@ public class MetricsRestControllerTest {
         QueryRegistrationCache queryRegistrationCache = new QueryRegistrationCache(new RoundRobinQueryHandlerSelector());
         queryClient = new ClientIdentification("context", "testclient");
         queryRegistrationCache.add(new QueryDefinition("context", "query"), "result",
-                                   new QueryHandler(queryClient, "testcomponent") {
-                                       @Override
-                                       public void dispatch(SubscriptionQueryRequest query) {
-
-                                       }
-                                   });
+                                   new FakeQueryHandler(queryClient, "testcomponent"));
         principal = mock(Principal.class);
         when(principal.getName()).thenReturn("Testuser");
         queryMetricsRegistry = new QueryMetricsRegistry(new MeterFactory(new SimpleMeterRegistry(), new DefaultMetricCollector()));

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/MetricsRestControllerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/MetricsRestControllerTest.java
@@ -57,11 +57,6 @@ public class MetricsRestControllerTest {
             }
 
             @Override
-            public void confirm(String messageId) {
-
-            }
-
-            @Override
             public int compareTo(@NotNull CommandHandler o) {
                 return 0;
             }

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/MetricsRestControllerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/MetricsRestControllerTest.java
@@ -49,8 +49,7 @@ public class MetricsRestControllerTest {
         CommandRegistrationCache commandRegistrationCache = new CommandRegistrationCache();
         testclient = new ClientIdentification(Topology.DEFAULT_CONTEXT,
                                                                    "testclient");
-        commandRegistrationCache.add("Sample", new CommandHandler<Object>(null,
-                                                                          testclient, "testcomponent") {
+        commandRegistrationCache.add("Sample", new CommandHandler(testclient, "testcomponent") {
             @Override
             public void dispatch(SerializedCommand request) {
 
@@ -66,13 +65,12 @@ public class MetricsRestControllerTest {
         QueryRegistrationCache queryRegistrationCache = new QueryRegistrationCache(new RoundRobinQueryHandlerSelector());
         queryClient = new ClientIdentification("context", "testclient");
         queryRegistrationCache.add(new QueryDefinition("context", "query"), "result",
-                                   new QueryHandler<Object>(null,
-                                                            queryClient, "testcomponent") {
-            @Override
-            public void dispatch(SubscriptionQueryRequest query) {
+                                   new QueryHandler(queryClient, "testcomponent") {
+                                       @Override
+                                       public void dispatch(SubscriptionQueryRequest query) {
 
-            }
-        });
+                                       }
+                                   });
         principal = mock(Principal.class);
         when(principal.getName()).thenReturn("Testuser");
         queryMetricsRegistry = new QueryMetricsRegistry(new MeterFactory(new SimpleMeterRegistry(), new DefaultMetricCollector()));

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/QueryRestControllerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/QueryRestControllerTest.java
@@ -13,20 +13,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.axoniq.axonserver.component.query.Query;
 import io.axoniq.axonserver.grpc.query.QuerySubscription;
 import io.axoniq.axonserver.message.ClientIdentification;
-import io.axoniq.axonserver.message.query.DirectQueryHandler;
+import io.axoniq.axonserver.message.query.FakeQueryHandler;
 import io.axoniq.axonserver.message.query.QueryDefinition;
 import io.axoniq.axonserver.message.query.QueryDispatcher;
 import io.axoniq.axonserver.message.query.QueryRegistrationCache;
 import io.axoniq.axonserver.serializer.GsonMedia;
 import io.axoniq.axonserver.topology.Topology;
-import io.axoniq.axonserver.util.CountingStreamObserver;
 import org.junit.*;
 
 import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Marc Gathier
@@ -46,7 +45,9 @@ public class QueryRestControllerTest {
                 .setClientId("client")
                 .setNrOfHandlers(1).build();
         registationCache.add(new QueryDefinition(Topology.DEFAULT_CONTEXT, querySubscription), "Response",
-                             new DirectQueryHandler(new CountingStreamObserver<>(), new ClientIdentification(Topology.DEFAULT_CONTEXT, querySubscription.getClientId()), querySubscription.getComponentName()));
+                             new FakeQueryHandler(new ClientIdentification(Topology.DEFAULT_CONTEXT,
+                                                                           querySubscription.getClientId()),
+                                                  querySubscription.getComponentName()));
 
         testSubject = new QueryRestController(registationCache, queryDispatcher);
     }


### PR DESCRIPTION
The base classes for the QueryHandler and CommandHandler had too much detail in them, making it difficult to make other implementations. 
Client class needs to expose axonServerNode and componentName. 