### PR TITLE
Use local store for querying/listing events

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -530,7 +530,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
 
 
         private void cancelTrackingEventProcessors() {
-            trackingEventManager.stopAll();
+            trackingEventManager.stopAllWhereRequestIsNotForLocalStoreOnly();
         }
 
         /**

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -530,7 +530,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
 
 
         private void cancelTrackingEventProcessors() {
-            trackingEventManager.stopAllWhereRequestIsNotForLocalStoreOnly();
+            trackingEventManager.stopAllWhereNotAllowedReadingFromFollower();
         }
 
         /**

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
@@ -157,10 +157,10 @@ public class TrackingEventProcessorManager {
     }
 
     /**
-     * Stops all tracking event processors where request is not for local store only.
+     * Stops all tracking event processors where request does not allow reading from follower.
      */
-    public void stopAllWhereRequestIsNotForLocalStoreOnly() {
-        eventTrackerSet.forEach(EventTracker::stopAllWhereRequestIsNotForLocalStoreOnly);
+    public void stopAllWhereNotAllowedReadingFromFollower() {
+        eventTrackerSet.forEach(EventTracker::stopAllWhereNotAllowedReadingFromFollower);
     }
 
     /**
@@ -202,7 +202,7 @@ public class TrackingEventProcessorManager {
         private volatile boolean running = true;
         private final Set<PayloadDescription> blacklistedTypes = new CopyOnWriteArraySet<>();
         private volatile int force = blacklistedSendAfter;
-        private final boolean requestToUseLocalStore;
+        private final boolean allowReadingFromFollower;
 
         private EventTracker(GetEventsRequest request, StreamObserver<InputStream> eventStream) {
             permits = new AtomicInteger((int) request.getNumberOfPermits());
@@ -212,7 +212,7 @@ public class TrackingEventProcessorManager {
             if (request.getBlacklistCount() > 0) {
                 addBlacklist(request.getBlacklistList());
             }
-            requestToUseLocalStore = request.getUseLocalStore();
+            allowReadingFromFollower = request.getAllowReadingFromFollower();
             this.eventStream = eventStream;
         }
 
@@ -284,8 +284,8 @@ public class TrackingEventProcessorManager {
             StreamObserverUtils.complete(eventStream);
         }
 
-        public void stopAllWhereRequestIsNotForLocalStoreOnly() {
-            if (!requestToUseLocalStore) {
+        public void stopAllWhereNotAllowedReadingFromFollower() {
+            if (!allowReadingFromFollower) {
                 stop();
             }
         }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
@@ -157,6 +157,13 @@ public class TrackingEventProcessorManager {
     }
 
     /**
+     * Stops all tracking event processors where request is not for local store only.
+     */
+    public void stopAllWhereRequestIsNotForLocalStoreOnly() {
+        eventTrackerSet.forEach(EventTracker::stopAllWhereRequestIsNotForLocalStoreOnly);
+    }
+
+    /**
      * Kills all tracking event processors that are waiting for permits and not received any permits since minLastPermits.
      * @param minLastPermits expected minimum timestamp for new permits request
      */
@@ -195,6 +202,7 @@ public class TrackingEventProcessorManager {
         private volatile boolean running = true;
         private final Set<PayloadDescription> blacklistedTypes = new CopyOnWriteArraySet<>();
         private volatile int force = blacklistedSendAfter;
+        private final boolean requestToUseLocalStore;
 
         private EventTracker(GetEventsRequest request, StreamObserver<InputStream> eventStream) {
             permits = new AtomicInteger((int) request.getNumberOfPermits());
@@ -204,6 +212,7 @@ public class TrackingEventProcessorManager {
             if (request.getBlacklistCount() > 0) {
                 addBlacklist(request.getBlacklistList());
             }
+            requestToUseLocalStore = request.getUseLocalStore();
             this.eventStream = eventStream;
         }
 
@@ -273,6 +282,12 @@ public class TrackingEventProcessorManager {
         public void stop() {
             close();
             StreamObserverUtils.complete(eventStream);
+        }
+
+        public void stopAllWhereRequestIsNotForLocalStoreOnly() {
+            if (!requestToUseLocalStore) {
+                stop();
+            }
         }
 
         public void validateActiveConnection(long minLastPermits) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -342,7 +342,7 @@ public class EventDispatcher implements AxonServerClientService {
 
             @Override
             public void onNext(QueryEventsRequest request) {
-                EventStore eventStore = request.getUseLocalStore() ? localEventStore : leaderEventStore;
+                EventStore eventStore = request.getAllowReadingFromFollower() ? localEventStore : leaderEventStore;
                 if (eventStore == null) {
                     responseObserver.onError(new MessagingPlatformException(ErrorCode.NO_EVENTSTORE,
                                                                             NO_EVENT_STORE_CONFIGURED + context));
@@ -485,7 +485,7 @@ public class EventDispatcher implements AxonServerClientService {
             if( eventStoreRequestObserver == null) {
                 trackerInfo = new EventTrackerInfo(responseObserver, getEventsRequest.getClientId(), context,getEventsRequest.getTrackingToken()-1);
                 try {
-                    EventStore eventStore = getEventsRequest.getUseLocalStore() ? localEventStore : leaderEventStore;
+                    EventStore eventStore = getEventsRequest.getAllowReadingFromFollower() ? localEventStore : leaderEventStore;
                     if (eventStore == null) {
                         responseObserver.onError(new MessagingPlatformException(ErrorCode.NO_EVENTSTORE,
                                                                                 NO_EVENT_STORE_CONFIGURED + context));

--- a/axonserver/src/main/java/io/axoniq/axonserver/topology/DefaultEventStoreLocator.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/topology/DefaultEventStoreLocator.java
@@ -16,10 +16,12 @@ import javax.annotation.PostConstruct;
 
 /**
  * Default implementation for an EventStoreLocator.
+ *
  * @author Marc Gathier
  * @since 4.0
  */
 public class DefaultEventStoreLocator implements EventStoreLocator {
+
     private final LocalEventStore localEventStore;
 
     public DefaultEventStoreLocator(LocalEventStore localEventStore) {
@@ -37,10 +39,10 @@ public class DefaultEventStoreLocator implements EventStoreLocator {
     }
 
     @Override
-    public EventStore getEventStore(String context) {
-        if( Topology.DEFAULT_CONTEXT.equals(context))
+    public EventStore getEventStore(String context, boolean useLocal) {
+        if (Topology.DEFAULT_CONTEXT.equals(context)) {
             return localEventStore;
+        }
         return null;
     }
-
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/topology/EventStoreLocator.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/topology/EventStoreLocator.java
@@ -35,5 +35,18 @@ public interface EventStoreLocator {
      * @param context the context to get the eventstore for
      * @return an EventStore
      */
-    EventStore getEventStore(String context);
+    default EventStore getEventStore(String context) {
+        return getEventStore(context, false);
+    }
+
+    /**
+     * Retrieve an EventStore instance which can be used to store and retrieve events. Returns null when there is no
+     * leader for the specified context.
+     *
+     * @param context  the context to get the local EventStore for
+     * @param useLocal use local event store (if possible - if current node has event store for this context, otherwise
+     *                 opens a remote connection)
+     * @return an EventStore
+     */
+    EventStore getEventStore(String context, boolean useLocal);
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManagerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManagerTest.java
@@ -96,8 +96,7 @@ public class TrackingEventProcessorManagerTest {
                 testSubject.createEventTracker(request,
                                                new StreamObserver<InputStream>() {
                                                    @Override
-                                                   public void onNext(
-                                                           InputStream value) {
+                                                   public void onNext(InputStream value) {
                                                        messagesReceived.incrementAndGet();
                                                    }
 
@@ -159,5 +158,46 @@ public class TrackingEventProcessorManagerTest {
                                                    }
                                                });
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(10, messagesReceived.get()));
+    }
+
+    @Test
+    public void testStopAllWhereRequestIsNotForLocalStoreOnly() throws InterruptedException {
+        GetEventsRequest requestUseLocalStore = GetEventsRequest.newBuilder()
+                                                                .setTrackingToken(100)
+                                                                .setNumberOfPermits(5)
+                                                                .setUseLocalStore(true)
+                                                                .build();
+        AtomicInteger useLocalStoreMessagesReceived = new AtomicInteger();
+        AtomicBoolean useLocalStoreCompleted = new AtomicBoolean();
+        AtomicBoolean useLocalStoreFailed = new AtomicBoolean();
+
+        TrackingEventProcessorManager.EventTracker useLocalStoreTracker = testSubject.createEventTracker(
+                requestUseLocalStore,
+                new StreamObserver<InputStream>() {
+                    @Override
+                    public void onNext(InputStream value) {
+                        useLocalStoreMessagesReceived.incrementAndGet();
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        useLocalStoreFailed.set(true);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        useLocalStoreCompleted.set(true);
+                    }
+                });
+
+        assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(5, useLocalStoreMessagesReceived.get()));
+        assertFalse(useLocalStoreCompleted.get());
+        assertFalse(useLocalStoreFailed.get());
+
+        testSubject.stopAllWhereRequestIsNotForLocalStoreOnly();
+
+        useLocalStoreTracker.addPermits(5);
+
+        assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(10, useLocalStoreMessagesReceived.get()));
     }
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManagerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManagerTest.java
@@ -165,7 +165,7 @@ public class TrackingEventProcessorManagerTest {
         GetEventsRequest requestUseLocalStore = GetEventsRequest.newBuilder()
                                                                 .setTrackingToken(100)
                                                                 .setNumberOfPermits(5)
-                                                                .setUseLocalStore(true)
+                                                                .setAllowReadingFromFollower(true)
                                                                 .build();
         AtomicInteger useLocalStoreMessagesReceived = new AtomicInteger();
         AtomicBoolean useLocalStoreCompleted = new AtomicBoolean();
@@ -194,7 +194,7 @@ public class TrackingEventProcessorManagerTest {
         assertFalse(useLocalStoreCompleted.get());
         assertFalse(useLocalStoreFailed.get());
 
-        testSubject.stopAllWhereRequestIsNotForLocalStoreOnly();
+        testSubject.stopAllWhereNotAllowedReadingFromFollower();
 
         useLocalStoreTracker.addPermits(5);
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
@@ -133,10 +133,15 @@ public class EventDispatcherTest {
             return eventStoreResponseStream;
         });
         StreamObserver<GetEventsRequest> inputStream = testSubject.listEvents(responseObserver);
-        inputStream.onNext(GetEventsRequest.newBuilder().setClientId("sampleClient").build());
+        inputStream.onNext(GetEventsRequest.newBuilder()
+                                           .setClientId("sampleClient")
+                                           .build());
         verify(eventStoreLocator).getEventStore(Topology.DEFAULT_CONTEXT, false);
         assertEquals(1, responseObserver.count);
-        inputStream.onNext(GetEventsRequest.newBuilder().setUseLocalStore(true).setClientId("sampleClient").build());
+        inputStream.onNext(GetEventsRequest.newBuilder()
+                                           .setAllowReadingFromFollower(true)
+                                           .setClientId("sampleClient")
+                                           .build());
         verify(eventStoreLocator).getEventStore(Topology.DEFAULT_CONTEXT, true);
         assertTrue(responseObserver.completed);
         testSubject.on(new TopologyEvents.ApplicationDisconnected(Topology.DEFAULT_CONTEXT, "myComponent", "sampleClient"));
@@ -173,7 +178,9 @@ public class EventDispatcherTest {
         inputStream.onNext(QueryEventsRequest.newBuilder().build());
         verify(eventStoreLocator).getEventStore(Topology.DEFAULT_CONTEXT, false);
         assertEquals(1, responseObserver.count);
-        inputStream.onNext(QueryEventsRequest.newBuilder().setUseLocalStore(true).build());
+        inputStream.onNext(QueryEventsRequest.newBuilder()
+                                             .setAllowReadingFromFollower(true)
+                                             .build());
         verify(eventStoreLocator).getEventStore(Topology.DEFAULT_CONTEXT, true);
         assertTrue(responseObserver.completed);
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
@@ -138,6 +138,7 @@ public class EventDispatcherTest {
                                            .build());
         verify(eventStoreLocator).getEventStore(Topology.DEFAULT_CONTEXT, false);
         assertEquals(1, responseObserver.count);
+        inputStream = testSubject.listEvents(responseObserver);
         inputStream.onNext(GetEventsRequest.newBuilder()
                                            .setAllowReadingFromFollower(true)
                                            .setClientId("sampleClient")

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
         <netty.version>4.1.35.Final</netty.version>
         <projectreactor.version>3.1.7.RELEASE</projectreactor.version>
-        <axonserver.api.version>4.3</axonserver.api.version>
+        <axonserver.api.version>4.4-SNAPSHOT</axonserver.api.version>
         <h2.version>1.4.197</h2.version>
     </properties>
 


### PR DESCRIPTION
Use local event store (if possible) for list and query events methods (depending on the request).

Relates to https://github.com/AxonIQ/axon-server-api/pull/20