### PR TITLE
Concurrency fixes

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -291,6 +291,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
                     if (c == null) {
                         return workers(context).createEventTracker(getEventsRequest.getTrackingToken(),
                                                                    getEventsRequest.getClientId(),
+                                                                   getEventsRequest.getAllowReadingFromFollower(),
                                                                    responseStreamObserver);
                     }
                     return c;
@@ -535,9 +536,14 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
             meterFactory.remove(gauge);
         }
 
-        private TrackingEventProcessorManager.EventTracker createEventTracker(long trackingToken, String clientId,
+        private TrackingEventProcessorManager.EventTracker createEventTracker(long trackingToken,
+                                                                              String clientId,
+                                                                              boolean allowReadingFromFollower,
                                                                               StreamObserver<InputStream> eventStream) {
-            return trackingEventManager.createEventTracker(trackingToken, clientId, eventStream);
+            return trackingEventManager.createEventTracker(trackingToken,
+                                                           clientId,
+                                                           allowReadingFromFollower,
+                                                           eventStream);
         }
 
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
@@ -131,13 +131,15 @@ public class TrackingEventProcessorManager {
     /**
      * Creates a new event tracker.
      *
-     * @param trackingToken the tracking token to start tracking events from
-     * @param clientId      the id of the client
-     * @param eventStream   the output stream
+     * @param trackingToken            the tracking token to start tracking events from
+     * @param clientId                 the id of the client
+     * @param allowReadingFromFollower whether reading events from follower is allowed
+     * @param eventStream              the output stream
      * @return an EventTracker
      */
-    EventTracker createEventTracker(long trackingToken, String clientId, StreamObserver<InputStream> eventStream) {
-        return new EventTracker(trackingToken, clientId, eventStream);
+    EventTracker createEventTracker(long trackingToken, String clientId, boolean allowReadingFromFollower,
+                                    StreamObserver<InputStream> eventStream) {
+        return new EventTracker(trackingToken, clientId, allowReadingFromFollower, eventStream);
     }
 
     /**
@@ -204,11 +206,13 @@ public class TrackingEventProcessorManager {
         private volatile int force = blacklistedSendAfter;
         private final boolean allowReadingFromFollower;
 
-        private EventTracker(long trackingToken, String clientId, StreamObserver<InputStream> eventStream) {
+        private EventTracker(long trackingToken, String clientId, boolean allowReadingFromFollower,
+                             StreamObserver<InputStream> eventStream) {
             client = clientId;
             lastPermitTimestamp = new AtomicLong(System.currentTimeMillis());
             nextToken = new AtomicLong(trackingToken);
             this.eventStream = eventStream;
+            this.allowReadingFromFollower = allowReadingFromFollower;
         }
 
         private int sendNext() {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
@@ -60,6 +60,8 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
     private static final Logger logger = LoggerFactory.getLogger(QueryEventsRequestStreamObserver.class);
 
     private static final ScheduledExecutorService senderService = Executors.newScheduledThreadPool(3,
+                                                                                                   new CustomizableThreadFactory(
+                                                                                                           "ad-hoc-query-"));
 
     private final EventWriteStorage eventWriteStorage;
     private final EventStreamReader eventStreamReader;

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManagerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManagerTest.java
@@ -91,6 +91,7 @@ public class TrackingEventProcessorManagerTest {
         TrackingEventProcessorManager.EventTracker tracker =
                 testSubject.createEventTracker(100L,
                                                "",
+                                               true,
                                                new StreamObserver<InputStream>() {
                                                    @Override
                                                    public void onNext(InputStream value) {
@@ -133,6 +134,7 @@ public class TrackingEventProcessorManagerTest {
         TrackingEventProcessorManager.EventTracker tracker =
                 testSubject.createEventTracker(100L,
                                                "",
+                                               true,
                                                new StreamObserver<InputStream>() {
                                                    @Override
                                                    public void onNext(
@@ -161,17 +163,14 @@ public class TrackingEventProcessorManagerTest {
 
     @Test
     public void testStopAllWhereRequestIsNotForLocalStoreOnly() throws InterruptedException {
-        GetEventsRequest requestUseLocalStore = GetEventsRequest.newBuilder()
-                                                                .setTrackingToken(100)
-                                                                .setNumberOfPermits(5)
-                                                                .setAllowReadingFromFollower(true)
-                                                                .build();
         AtomicInteger useLocalStoreMessagesReceived = new AtomicInteger();
         AtomicBoolean useLocalStoreCompleted = new AtomicBoolean();
         AtomicBoolean useLocalStoreFailed = new AtomicBoolean();
 
         TrackingEventProcessorManager.EventTracker useLocalStoreTracker = testSubject.createEventTracker(
-                requestUseLocalStore,
+                100,
+                "",
+                true,
                 new StreamObserver<InputStream>() {
                     @Override
                     public void onNext(InputStream value) {
@@ -188,6 +187,8 @@ public class TrackingEventProcessorManagerTest {
                         useLocalStoreCompleted.set(true);
                     }
                 });
+        useLocalStoreTracker.addPermits(5);
+        useLocalStoreTracker.start();
 
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(5, useLocalStoreMessagesReceived.get()));
         assertFalse(useLocalStoreCompleted.get());

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/HttpStreamingQueryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/HttpStreamingQueryTest.java
@@ -169,16 +169,12 @@ public class HttpStreamingQueryTest {
             latch.countDown();
         });
 
-        emitter.onCompletion(()-> {
-            latch.countDown();
-        });
+        emitter.onCompletion(latch::countDown);
 
-        emitter.onTimeout(() -> latch.countDown());
+        emitter.onTimeout(latch::countDown);
         testSubject.query(Topology.DEFAULT_CONTEXT, "aggregateIdentifier = \"demo\" | limit( 10)", "token", emitter);
 
         latch.await(1, TimeUnit.SECONDS);
         assertEquals(13, messages.size());
-
-
     }
 }


### PR DESCRIPTION
Ensures that there are no multiple trackers/senders on list/query events requests.