### PR TITLE
 Replaced emitterprocessor with simple atomic boolean and scheduled task

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandMetricsWebSocket.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandMetricsWebSocket.java
@@ -44,9 +44,12 @@ public class CommandMetricsWebSocket {
         this.webSocket = webSocket;
     }
 
-    @Scheduled(initialDelayString = "10000", fixedRateString = "1000")
+    @Scheduled(initialDelayString = "${axoniq.axonserver.websocket-update.initial-delay:10000}",
+            fixedRateString = "${axoniq.axonserver.websocket-update.rate:1000}")
     public void publish() {
-        if( subscriptions.isEmpty()) return;
+        if (subscriptions.isEmpty()) {
+            return;
+        }
         commandRegistrationCache.getAll().forEach(
                 (commandHandler, registrations) -> getMetrics(commandHandler, registrations).forEach(
                         commandMetric -> webSocket.convertAndSend(DESTINATION, commandMetric)

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryMetricsWebSocket.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryMetricsWebSocket.java
@@ -46,9 +46,12 @@ public class QueryMetricsWebSocket {
         this.webSocket = webSocket;
     }
 
-    @Scheduled(initialDelayString = "10000", fixedRateString = "1000")
+    @Scheduled(initialDelayString = "${axoniq.axonserver.websocket-update.initial-delay:10000}",
+            fixedRateString = "${axoniq.axonserver.websocket-update.rate:1000}")
     public void publish() {
-        if( subscriptions.isEmpty()) return;
+        if (subscriptions.isEmpty()) {
+            return;
+        }
         queryRegistrationCache.getAll().forEach(
                 (queryDefinition, handlersPerComponent) -> getMetrics(queryDefinition, handlersPerComponent).forEach(
                         commandMetric -> webSocket.convertAndSend(DESTINATION, commandMetric)

--- a/axonserver/src/test/java/io/axoniq/axonserver/websocket/WebsocketProcessorEventsSourceTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/websocket/WebsocketProcessorEventsSourceTest.java
@@ -12,7 +12,11 @@ package io.axoniq.axonserver.websocket;
 import io.axoniq.axonserver.applicationevents.EventProcessorEvents;
 import org.junit.*;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
 
@@ -24,9 +28,14 @@ public class WebsocketProcessorEventsSourceTest {
     @Test
     public void on() throws InterruptedException {
         AtomicInteger triggers = new AtomicInteger();
-        WebsocketProcessorEventsSource testSubject = new WebsocketProcessorEventsSource(e -> {
+        WebsocketProcessorEventsSource testSubject = new WebsocketProcessorEventsSource(() -> {
             triggers.incrementAndGet();
-        }, 10);
+        });
+        ScheduledFuture<?> scheduler = Executors.newSingleThreadScheduledExecutor()
+                                                .scheduleAtFixedRate(testSubject::applyIfUpdates,
+                                                                     10,
+                                                                     10,
+                                                                     TimeUnit.MILLISECONDS);
 
         testSubject.on(new EventProcessorEvents.EventProcessorStatusUpdate(null, true));
         testSubject.on(new EventProcessorEvents.EventProcessorStatusUpdate(null, true));
@@ -38,5 +47,31 @@ public class WebsocketProcessorEventsSourceTest {
         testSubject.on(new EventProcessorEvents.EventProcessorStatusUpdate(null, true));
         Thread.sleep(15);
         assertEquals(2, triggers.get());
+
+        scheduler.cancel(false);
+    }
+
+    @Test
+    public void onExecption() throws InterruptedException {
+        AtomicInteger triggers = new AtomicInteger();
+        WebsocketProcessorEventsSource testSubject = new WebsocketProcessorEventsSource(() -> {
+            if (triggers.getAndIncrement() == 5) {
+                throw new IllegalArgumentException("Failed");
+            }
+        });
+        ScheduledFuture<?> scheduler = Executors.newSingleThreadScheduledExecutor()
+                                                .scheduleAtFixedRate(testSubject::applyIfUpdates,
+                                                                     50,
+                                                                     50,
+                                                                     TimeUnit.MILLISECONDS);
+
+        for (int run = 0; run < 10; run++) {
+            IntStream.range(0, 1000).parallel().forEach(i -> testSubject
+                    .on(new EventProcessorEvents.EventProcessorStatusUpdate(null, true)));
+            Thread.sleep(100);
+        }
+
+        assertEquals(10, triggers.get());
+        scheduler.cancel(false);
     }
 }


### PR DESCRIPTION
Sometimes the flux stopped processing messages, causing the buffer to fill up and all threads to block. This could cause high CPU load (as all executor thread were constantly trying to add an entry in the flux, offer would fail, park 10 nanos and try again).