### PR TITLE
Offload expensive data-fetching operations to separate thread pool

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/config/MessagingPlatformConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/MessagingPlatformConfiguration.java
@@ -134,12 +134,12 @@ public class MessagingPlatformConfiguration {
     /**
      * Number of threads for executing incoming gRPC requests
      */
-    private int executorThreadCount = 16;
+    private int executorThreadCount = 4;
 
     /**
      * Number of threads for executing incoming gRPC requests for internal communication
      */
-    private int clusterExecutorThreadCount = 16;
+    private int clusterExecutorThreadCount = 4;
 
     public MessagingPlatformConfiguration(SystemInfoProvider systemInfoProvider) {
         this.systemInfoProvider = systemInfoProvider;


### PR DESCRIPTION
The handler threads for grpc requests from clients and peer nodes has been greatly reduced (from 16 to 4). These 24 threads have been assigned to a separate pool used for data fetching operations. This should prevent the grpc threads to block to the extent where messages with higher priority are blocked by read operations.