### PR TITLE
Adding latency (as part of four golden signals) to metrics for commands, queries and events.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dev/node2/**
 dev/node3/**
 
 data/
+AxonIQ.pid 

--- a/axonserver-grpc/pom.xml
+++ b/axonserver-grpc/pom.xml
@@ -41,6 +41,12 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/TrackingProcessor.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/TrackingProcessor.java
@@ -67,7 +67,7 @@ public class TrackingProcessor extends GenericProcessor implements EventProcesso
 
     @Override
     public void printOn(Media media) {
-        EventProcessor.super.printOn(media);
+        super.printOn(media);
 
         Set<String> freeThreadInstances =
                 processors().stream()

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryMetricsRegistry.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryMetricsRegistry.java
@@ -102,7 +102,15 @@ public class QueryMetricsRegistry {
      */
     public QueryMetric queryMetric(QueryDefinition query, ClientIdentification clientId, String componentName){
         ClusterMetric clusterMetric = clusterMetric(query, clientId);
-        return new QueryMetric(query, clientId.metricName(), componentName, clusterMetric.count());
+
+        return new QueryMetric(
+                query,
+                clientId.metricName(),
+                componentName,
+                clusterMetric.count(),
+                clusterMetric.mean(),
+                clusterMetric.max()
+        );
     }
 
     /**
@@ -131,18 +139,25 @@ public class QueryMetricsRegistry {
         return meterFactory.rateMeter(meterName, Tags.of(MeterFactory.CONTEXT, context));
     }
 
+    public MeterFactory.RateMeter errorRate(String context, BaseMetricName meterName, String errorCode) {
+        return meterFactory.rateMeter(meterName, Tags.of(MeterFactory.CONTEXT, context, MeterFactory.ERROR_CODE, errorCode));
+    }
 
     public static class QueryMetric {
         private final QueryDefinition queryDefinition;
         private final String clientId;
         private final String componentName;
         private final long count;
+        private final double mean;
+        private final double max;
 
-        QueryMetric(QueryDefinition queryDefinition, String clientId, String componentName, double count) {
+        QueryMetric(QueryDefinition queryDefinition, String clientId, String componentName, double count, double mean, double max) {
             this.queryDefinition = queryDefinition;
             this.clientId = clientId;
             this.componentName = componentName;
             this.count = (long) count;
+            this.mean = mean;
+            this.max = max;
         }
 
         public QueryDefinition getQueryDefinition() {
@@ -159,6 +174,14 @@ public class QueryMetricsRegistry {
 
         public long getCount() {
             return count;
+        }
+
+        public double getMean() {
+            return mean;
+        }
+
+        public double getMax() {
+            return max;
         }
 
         @Override

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/QueryMetricsRegistryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/QueryMetricsRegistryTest.java
@@ -10,20 +10,24 @@
 package io.axoniq.axonserver.message.query;
 
 import io.axoniq.axonserver.message.ClientIdentification;
+import io.axoniq.axonserver.metric.BaseMetricName;
 import io.axoniq.axonserver.metric.DefaultMetricCollector;
 import io.axoniq.axonserver.metric.MeterFactory;
 import io.axoniq.axonserver.topology.Topology;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Marc Gathier
  */
 public class QueryMetricsRegistryTest {
+    private static final ClientIdentification CLIENT_IDENTIFICATION = new ClientIdentification(Topology.DEFAULT_CONTEXT, "processor");
+
     private QueryMetricsRegistry testSubject;
-    private ClientIdentification clientIdentification = new ClientIdentification(Topology.DEFAULT_CONTEXT, "processor");
+
     @Before
     public void setUp() {
         testSubject = new QueryMetricsRegistry(new MeterFactory(new SimpleMeterRegistry(), new DefaultMetricCollector()));
@@ -31,19 +35,41 @@ public class QueryMetricsRegistryTest {
 
     @Test
     public void add() {
-        testSubject.add(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"), "source", clientIdentification, 1L);
+        testSubject.add(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"), "source", CLIENT_IDENTIFICATION, 1L);
     }
 
     @Test
-    public void get()  {
-        testSubject.add(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"), "source", clientIdentification, 1L);
+    public void getSome() {
+        testSubject.add(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"), "source", CLIENT_IDENTIFICATION, 1L);
+        testSubject.add(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"), "source", CLIENT_IDENTIFICATION, 2L);
+
         QueryMetricsRegistry.QueryMetric queryMetric = testSubject
-                .queryMetric(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"), clientIdentification, "");
-        assertEquals(1, queryMetric.getCount());
-        queryMetric = testSubject.queryMetric(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"),
-                                              new ClientIdentification(Topology.DEFAULT_CONTEXT, "processor1"),
-                                              "");
+                .queryMetric(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"), CLIENT_IDENTIFICATION, "");
+
+        assertEquals(2L, queryMetric.getCount());
+        assertEquals(1.5, queryMetric.getMean(), Double.MIN_VALUE);
+        assertEquals(2.0, queryMetric.getMax(), Double.MIN_VALUE);
+    }
+
+    @Test
+    public void getNone() {
+        QueryMetricsRegistry.QueryMetric queryMetric = testSubject.queryMetric(new QueryDefinition(Topology.DEFAULT_CONTEXT, "a"),
+                new ClientIdentification(Topology.DEFAULT_CONTEXT, "processor1"),
+                "");
         assertEquals(0, queryMetric.getCount());
+    }
+
+    @Test
+    public void testErrorRates() {
+        MeterFactory.RateMeter errorRate1 = testSubject.errorRate("testContext", BaseMetricName.AXON_QUERY_RATE, "testError1");
+        MeterFactory.RateMeter errorRate2 = testSubject.errorRate("testContext", BaseMetricName.AXON_QUERY_RATE, "testError2");
+
+        errorRate1.mark();
+        errorRate1.mark();
+        errorRate2.mark();
+
+        assertEquals(2L, errorRate1.getCount());
+        assertEquals(1L, errorRate2.getCount());
     }
 
 }


### PR DESCRIPTION
~~WIP disclaimer~~

aim:
four golden signals summarized as: latency, traffic, saturation and error rate
enhance axon-server-se metrics to cover latency and error rate for commands and queries.

key questions:
- does that work together with axon-metrics cluster-collection?
    - assumed yes; DefaultMetricCollector is placeholder.
- fourth golden signal: error-rate
    - error-codes as tags on RateMeters
- actuator metrics hook
    - central instance of MetricsRegistry more precisely PrometheusMetricsRegistry does it all

sanity-checks:
- /actuator/metrics/axon.commands (no mean as PrometheusMeter does not calc mean)

out-of-scope / outlook:
- events measuring - how many events pass one grpc call?
- cover subscription query updates too
- can prometheus as backend of micrometer be replaced by stackdriver?
```
<!-- from axonserver pom.xml -->
<dependency>
            <groupId>io.micrometer</groupId>
            <artifactId>micrometer-registry-prometheus</artifactId>
</dependency>
```
See here: https://micrometer.io/docs/registry/stackdriver
- won't include /v1/query-metrics , /v1/command-metrics and alike in this PR
