### PR TITLE
ad-hoc query changes

### DIFF
--- a/axonserver-query-parser/src/main/java/io/axoniq/axonserver/queryparser/BaseQueryElement.java
+++ b/axonserver-query-parser/src/main/java/io/axoniq/axonserver/queryparser/BaseQueryElement.java
@@ -48,4 +48,7 @@ public abstract class BaseQueryElement implements PipelineEntry{
         return operator();
     }
 
+    public int size() {
+        return children.size();
+    }
 }

--- a/axonserver/package.json
+++ b/axonserver/package.json
@@ -24,11 +24,12 @@
     "cross-env": "^5.0.5",
     "css-loader": "^0.28.7",
     "file-loader": "^1.1.4",
+    "vue-clipboard2": "^0.3.1",
+    "vue-js-modal": "^1.3.16",
     "vue-loader": "^13.0.5",
-    "vue-template-compiler": "^2.4.4",
     "vue-simple-suggest": "!1.8.0",
+    "vue-template-compiler": "^2.4.4",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^3.1.11",
-    "vue-js-modal": "^1.3.16"
+    "webpack-dev-server": "^3.1.11"
   }
 }

--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>org.axonframework</groupId>
             <artifactId>axon-spring-boot-starter</artifactId>
-            <version>4.4-SNAPSHOT</version>
+            <version>4.3.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
@@ -148,12 +148,13 @@ public interface EventStorageEngine {
     CloseableIterator<SerializedTransactionWithToken> transactionIterator(long firstToken, long limitToken);
 
     /**
-     * Iterates through the events and calls {@link Predicate} for each event. When the predicate returns false processing stops.
-     * @param minToken minumum token of events to process
-     * @param minTimestamp minimum timestamp of events to process
-     * @param consumer applied for each event
+     * Iterates through the events and calls {@link Predicate} for each event. When the predicate returns false
+     * processing stops.
+     *
+     * @param queryOptions
+     * @param consumer     applied for each event
      */
-    void query(long minToken, long minTimestamp, Predicate<EventWithToken> consumer);
+    void query(QueryOptions queryOptions, Predicate<EventWithToken> consumer);
 
     /**
      * Gets filenames to back up for this storage engine. Only relevant for file based storage.

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStreamReader.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStreamReader.java
@@ -19,18 +19,20 @@ import java.util.function.Predicate;
  * @author Marc Gathier
  */
 public class EventStreamReader {
+
     private final EventStorageEngine eventStorageEngine;
 
     public EventStreamReader(EventStorageEngine datafileManagerChain) {
         this.eventStorageEngine = datafileManagerChain;
     }
 
-    public void query(long minToken, long minTimestamp, Predicate<EventWithToken> consumer) {
-        eventStorageEngine.query(minToken, minTimestamp, consumer);
+    public void query(QueryOptions queryOptions, Predicate<EventWithToken> consumer) {
+        eventStorageEngine.query(queryOptions, consumer);
     }
 
     /**
      * Returns the first token in the event store for the current context. Returns -1 if event store is empty.
+     *
      * @return the first token in this event store
      */
     public long getFirstToken() {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -471,6 +471,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
         Workers workers = workers(context);
         return new QueryEventsRequestStreamObserver(workers.eventWriteStorage,
                                                     workers.eventStreamReader,
+                                                    workers.aggregateReader,
                                                     defaultLimit,
                                                     timeout,
                                                     eventDecorator,

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/QueryOptions.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/QueryOptions.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017-2020 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.localstorage;
+
+/**
+ * Value object containing options to be used to pre-filter events for ad-hoc queries.
+ *
+ * @author Marc Gathier
+ * @since 4.4
+ */
+public class QueryOptions {
+
+    private final long minToken;
+    private final long maxToken;
+    private final long minTimestamp;
+
+    /**
+     * @param minToken     minumum token of events to process
+     * @param maxToken     maximum token of events to process
+     * @param minTimestamp minimum timestamp of events to process
+     */
+    public QueryOptions(long minToken, long maxToken, long minTimestamp) {
+        this.minToken = minToken;
+        this.maxToken = maxToken;
+        this.minTimestamp = minTimestamp;
+    }
+
+    public long getMinToken() {
+        return minToken;
+    }
+
+    public long getMaxToken() {
+        return maxToken;
+    }
+
+    public long getMinTimestamp() {
+        return minTimestamp;
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
@@ -9,19 +9,23 @@
 
 package io.axoniq.axonserver.localstorage.query;
 
+import com.google.protobuf.ByteString;
 import io.axoniq.axonserver.exception.ErrorCode;
 import io.axoniq.axonserver.exception.ExceptionUtils;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
 import io.axoniq.axonserver.grpc.event.ColumnsResponse;
 import io.axoniq.axonserver.grpc.event.Confirmation;
+import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.EventWithToken;
 import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
 import io.axoniq.axonserver.grpc.event.QueryValue;
 import io.axoniq.axonserver.grpc.event.RowResponse;
+import io.axoniq.axonserver.localstorage.AggregateReader;
 import io.axoniq.axonserver.localstorage.EventDecorator;
 import io.axoniq.axonserver.localstorage.EventStreamReader;
 import io.axoniq.axonserver.localstorage.EventWriteStorage;
+import io.axoniq.axonserver.localstorage.QueryOptions;
 import io.axoniq.axonserver.localstorage.Registration;
 import io.axoniq.axonserver.localstorage.SerializedEvent;
 import io.axoniq.axonserver.localstorage.query.result.AbstractMapExpressionResult;
@@ -32,7 +36,10 @@ import io.axoniq.axonserver.localstorage.query.result.MapExpressionResult;
 import io.axoniq.axonserver.localstorage.query.result.NumericExpressionResult;
 import io.axoniq.axonserver.localstorage.query.result.TimestampExpressionResult;
 import io.axoniq.axonserver.queryparser.EventStoreQueryParser;
+import io.axoniq.axonserver.queryparser.FunctionExpr;
+import io.axoniq.axonserver.queryparser.Numeric;
 import io.axoniq.axonserver.queryparser.Query;
+import io.axoniq.axonserver.queryparser.QueryElement;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +47,7 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -58,27 +66,33 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEventsRequest> {
 
+    public static final int TIME_WINDOW_FIELD = 100;
+    public static final String TIME_WINDOW_CUSTOM = "custom";
     private static final Logger logger = LoggerFactory.getLogger(QueryEventsRequestStreamObserver.class);
 
     private static final ScheduledExecutorService senderService = Executors.newScheduledThreadPool(3,
                                                                                                    new CustomizableThreadFactory(
                                                                                                            "ad-hoc-query-"));
+    public static final String COLUMN_NAME_TOKEN = "token";
 
     private final EventWriteStorage eventWriteStorage;
     private final EventStreamReader eventStreamReader;
+    private final AggregateReader aggregateReader;
     private final long defaultLimit;
     private final long timeout;
     private final EventDecorator eventDecorator;
     private final StreamObserver<QueryEventsResponse> responseObserver;
+    private final AtomicReference<Sender> senderRef = new AtomicReference<>();
     private volatile Registration registration;
     private volatile Pipeline pipeLine;
-    private final AtomicReference<Sender> senderRef = new AtomicReference<>();
 
     public QueryEventsRequestStreamObserver(EventWriteStorage eventWriteStorage, EventStreamReader eventStreamReader,
+                                            AggregateReader aggregateReader,
                                             long defaultLimit, long timeout, EventDecorator eventDecorator,
                                             StreamObserver<QueryEventsResponse> responseObserver) {
         this.eventWriteStorage = eventWriteStorage;
         this.eventStreamReader = eventStreamReader;
+        this.aggregateReader = aggregateReader;
         this.defaultLimit = defaultLimit;
         this.timeout = timeout;
         this.eventDecorator = eventDecorator;
@@ -96,31 +110,74 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
                 }
                 return s;
             });
-            if(sender.start()) {
+            if (sender.start()) {
                 long connectionToken = eventStreamReader.getLastToken();
+                long maxToken = Long.MAX_VALUE;
                 long minConnectionToken = StringUtils.isEmpty(queryEventsRequest.getQuery()) ? Math.max(
                         connectionToken - defaultLimit, 0) : 0;
                 String queryString = StringUtils.isEmpty(queryEventsRequest.getQuery()) ?
                         "token >= " + minConnectionToken + "| sortby(token)" : queryEventsRequest.getQuery();
+                String timeWindow = getTimeWindow(queryEventsRequest);
+                if (!TIME_WINDOW_CUSTOM.equals(timeWindow)) {
+                    queryString = queryString + " | " + timeWindow;
+                }
 
                 Query query = new EventStoreQueryParser().parse(queryString);
                 query.addDefaultLimit(defaultLimit);
+                String aggregateIdentifier = null;
+                for (int i = 0; i < query.size(); i++) {
+                    if (query.get(i) instanceof FunctionExpr) {
+                        FunctionExpr functionExpr = (FunctionExpr) query.get(i);
+                        if (isProjectOperation(functionExpr.operator())) {
+                            break;
+                        }
+                        if (COLUMN_NAME_TOKEN.equals(functionExpr.getParameters().get(0).getLiteral()) &&
+                                operatorIn(functionExpr.operator(), "=", ">", ">=")) {
+                            minConnectionToken = getValueAsLong(minConnectionToken,
+                                                                functionExpr.getParameters().get(1));
+                        }
+                        if (COLUMN_NAME_TOKEN.equals(functionExpr.getParameters().get(0).getLiteral()) &&
+                                operatorIn(functionExpr.operator(), "<", "<=", "=")) {
+                            maxToken = getValueAsLong(maxToken, functionExpr.getParameters().get(1));
+                        }
+                        if ("aggregateIdentifier".equals(functionExpr.getParameters().get(0).getLiteral()) &&
+                                "=".equals(functionExpr.operator())) {
+                            aggregateIdentifier = functionExpr.getParameters().get(1).getLiteral();
+                        }
+                    }
+                }
                 logger.info("Executing query: {}", query);
-
                 pipeLine = new QueryProcessor().buildPipeline(query, this::send);
-                sendColumns(pipeLine);
-                if (queryEventsRequest.getLiveEvents()) {
+                sendColumns(pipeLine, aggregateIdentifier != null);
+                if (queryEventsRequest.getLiveEvents() && maxToken > connectionToken) {
                     registration = eventWriteStorage.registerEventListener((token, events) -> pushEventFromStream(token,
                                                                                                                   events,
                                                                                                                   pipeLine));
                 }
-                senderService.submit(() -> {
-                    eventStreamReader.query(minConnectionToken,
-                                            query.getStartTime(),
-                                            event -> pushEvent(event, pipeLine));
-                    Optional.ofNullable(senderRef.get())
-                            .ifPresent(Sender::completed);
-                });
+                if (aggregateIdentifier == null) {
+                    QueryOptions queryOptions = new QueryOptions(minConnectionToken, maxToken, query.getStartTime());
+                    senderService.submit(() -> {
+                        eventStreamReader.query(queryOptions,
+                                                event -> pushEvent(event, pipeLine));
+                        Optional.ofNullable(senderRef.get())
+                                .ifPresent(Sender::completed);
+                    });
+                } else {
+                    String finalAggregateIdentifier = aggregateIdentifier;
+                    senderService.submit(() -> {
+                        aggregateReader.readEvents(finalAggregateIdentifier, false, 0, serializedEvent -> {
+                            Event event = serializedEvent.asEvent();
+                            if (event.getTimestamp() >= query.getStartTime()) {
+                                pushEvent(EventWithToken.newBuilder()
+                                                        .setEvent(event)
+                                                        .setToken(event.getAggregateSequenceNumber())
+                                                        .build(), pipeLine);
+                            }
+                        });
+                        Optional.ofNullable(senderRef.get())
+                                .ifPresent(Sender::completed);
+                    });
+                }
             } else {
                 Optional.ofNullable(senderRef.get())
                         .ifPresent(s -> s.addPermits(queryEventsRequest.getNumberOfPermits()));
@@ -129,6 +186,46 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
             responseObserver.onError(pe);
             senderRef.set(null);
         }
+    }
+
+    private long getValueAsLong(long maxToken, QueryElement value) {
+        if (value instanceof Numeric) {
+            try {
+                maxToken = Long.parseLong(value.getLiteral());
+            } catch (NumberFormatException ignore) {
+                // ignore exception as this code is for optimization only
+            }
+        }
+        return maxToken;
+    }
+
+    private boolean operatorIn(String operator, String... choices) {
+        for (String choice : choices) {
+            if (choice.equals(operator)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isProjectOperation(String operator) {
+        return "count".equals(operator)
+                || "min".equals(operator)
+                || "max".equals(operator)
+                || "avg".equals(operator)
+                || "sum".equals(operator)
+                || "select".equals(operator)
+                || "groupby".equals(operator);
+    }
+
+    private String getTimeWindow(QueryEventsRequest queryEventsRequest) {
+        List<ByteString> timeWindowList = queryEventsRequest.getUnknownFields().getField(TIME_WINDOW_FIELD)
+                                                            .getLengthDelimitedList();
+        if (timeWindowList.isEmpty()) {
+            return TIME_WINDOW_CUSTOM;
+        }
+
+        return timeWindowList.get(0).toStringUtf8();
     }
 
     private void pushEventFromStream(long firstToken, List<SerializedEvent> events, Pipeline pipeLine) {
@@ -176,9 +273,17 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
         }
     }
 
-    private void sendColumns(Pipeline pipeLine) {
+    private void sendColumns(Pipeline pipeLine, boolean hideToken) {
         Optional.ofNullable(senderRef.get())
-                .ifPresent(sender -> sender.sendColumnNames(pipeLine.columnNames(EventExpressionResult.COLUMN_NAMES)));
+                .ifPresent(sender -> {
+                    if (hideToken) {
+                        List<String> names = new ArrayList<>(pipeLine.columnNames(EventExpressionResult.COLUMN_NAMES));
+                        names.remove("token");
+                        sender.sendColumnNames(names);
+                    } else {
+                        sender.sendColumnNames(pipeLine.columnNames(EventExpressionResult.COLUMN_NAMES));
+                    }
+                });
     }
 
     private boolean send(QueryResult exp) {
@@ -214,10 +319,10 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
         private final Map<Object, QueryResult> messages = new HashMap<>();
         private final AtomicLong generatedId = new AtomicLong(0);
         private final AtomicLong permits;
+        private final AtomicBoolean started = new AtomicBoolean(false);
         private ScheduledFuture<?> sendTask;
         private List<String> columns;
         private volatile QueryEventsResponse completeMessage;
-        private final AtomicBoolean started = new AtomicBoolean(false);
 
         public Sender(long permits, boolean liveUpdates, long deadline) {
             this.liveUpdates = liveUpdates;

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/SearchController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/SearchController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import static io.axoniq.axonserver.localstorage.query.QueryEventsRequestStreamObserver.TIME_WINDOW_CUSTOM;
+
 /**
  * Rest service to perform queries on the event store.
  *
@@ -41,9 +43,12 @@ public class SearchController {
     @GetMapping
     public SseEmitter query(@RequestParam(value = "context", defaultValue = Topology.DEFAULT_CONTEXT) String context,
                             @RequestParam("query") String query,
+                            @RequestParam(value = "timewindow", required = false, defaultValue = TIME_WINDOW_CUSTOM) String timewindow,
+                            @RequestParam(value = "liveupdates", required = false, defaultValue = "false") Boolean liveupdates,
+                            @RequestParam(value = "forceleader", required = false, defaultValue = "false") Boolean forceReadFromLeader,
                             @RequestParam("clientToken") String clientToken) {
         SseEmitter sseEmitter = new SseEmitter(timeout);
-        httpStreamingQuery.query(context, query, clientToken, sseEmitter);
+        httpStreamingQuery.query(context, query, timewindow, liveupdates, forceReadFromLeader, clientToken, sseEmitter);
         return sseEmitter;
     }
 

--- a/axonserver/src/main/resources/static/query.html
+++ b/axonserver/src/main/resources/static/query.html
@@ -154,6 +154,10 @@
                         working: false,
                         contexts: [],
                         activeContext: "default",
+                        timeConstraint: "last hour",
+                        liveUpdates: false,
+                        forceReadFromLeader: false,
+                        activeRow: {value: []},
                         help: false
                     }, mounted() {
                 if (globals.isEnterprise()) {
@@ -167,22 +171,36 @@
                         toggleHelp() {
                             this.help = !this.help;
                         },
+                        select(row) {
+                            this.activeRow.style = "";
+                            this.activeRow = row;
+                            this.activeRow.style = "selected";
+                            this.$modal.show('result-details');
+                        },
+                        closeDetails(event) {
+                            this.activeRow.style = "";
+                            this.$forceUpdate();
+                        },
                         executeQuery() {
-                            if ( typeof EventSource === "undefined") {
+                            if (typeof EventSource === "undefined") {
                                 alert("No Server Emitter support in browser");
                                 return;
 
                             }
                             this.working = true;
                             this.query = $("#query").val();
+                            let effectiveQuery = this.query;
                             this.rows = [];
                             target = this;
                             if (source) {
                                 source.close();
                             }
                             source = new EventSource("v1/search?query=" + encodeURIComponent(this.query)
-                                    + "&context=" + encodeURIComponent(this.activeContext)
-                                    + "&clientToken="
+                                                             + "&context=" + encodeURIComponent(this.activeContext)
+                                                             + "&timewindow=" + encodeURIComponent(this.timeConstraint)
+                                                             + "&liveupdates=" + this.liveUpdates
+                                                             + "&forceleader=" + this.forceReadFromLeader
+                                                             + "&clientToken="
                                     + encodeURIComponent(clientToken));
                             source.addEventListener('metadata', function (event) {
                                 target.columns = JSON.parse(event.data);
@@ -266,11 +284,25 @@
     }
 </script>
 <div id="queryWrapper">
-    <div class="contextSelector" v-if="isEnterprise()">
-        Active context:
-        <select v-model="activeContext" >
+    <div class="contextSelector">
+        Query time window:
+        <select v-model="timeConstraint">
+            <option>last hour</option>
+            <option>last 2 hours</option>
+            <option>last day</option>
+            <option>last week</option>
+            <option>custom</option>
+        </select>
+
+        <input type="checkbox" v-model="liveUpdates">Live Updates</input>
+
+        <span v-if="isEnterprise()" style="margin-left: 15px;">
+        <input type="checkbox" v-model="forceReadFromLeader">Read from leader</input>
+            Active context:
+        <select v-model="activeContext">
             <option v-for="n in contexts">{{n}}</option>
         </select>
+        </span>
     </div>
     <br/>
     <form class="search-bar">
@@ -367,8 +399,8 @@
                 </th>
             </tr>
             </thead>
-            <tbody>
-            <tr v-for="row in rows">
+            <tbody class="selectable">
+            <tr v-for="row in rows" @click="select(row)" :class="row.style">
                 <td v-for="column in columns">
                     <div>{{row.value[column]}}</div>
                 </td>
@@ -376,4 +408,30 @@
             </tbody>
         </table>
     </div>
+
+    <modal name="result-details" width="900px" height="400px" :draggable="true" :resizable="true" :reset="true"
+           @before-close="closeDetails">
+        <div style="overflow-x: hidden; overflow-y: auto; height: 100%">
+            <table style="width: 95%">
+                <thead>
+                <tr>
+                    <th width="30%">Name</th>
+                    <th width="65%">Value</th>
+                    <th width="5%">Copy</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr v-for="column in columns">
+                    <td>{{column}}</td>
+                    <td>{{activeRow.value[column]}}</td>
+                    <td>
+                            <span v-clipboard:copy="activeRow.value[column]" title="Copy to clipboard">
+                                        <i class="far fa-copy"></i>
+                            </span>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </modal>
 </div>

--- a/axonserver/src/main/vuejs/main.js
+++ b/axonserver/src/main/vuejs/main.js
@@ -9,6 +9,7 @@
 
 import Vue from 'vue'
 import VModal from 'vue-js-modal'
+import VClipboard from 'vue-clipboard2'
 import ComponentInstances from './components/component/Instances.vue';
 import ComponentCommands from './components/component/Commands.vue';
 import ComponentQueries from './components/component/Queries.vue';
@@ -17,6 +18,7 @@ import ComponentCommandMetrics from './components/component/CommandMetrics.vue';
 import ComponentSubscriptionsMetrics from './components/component/SubscriptionsMetrics.vue';
 
 Vue.use(VModal)
+Vue.use(VClipboard)
 
 Vue.component('component-instances', ComponentInstances);
 Vue.component('component-commands', ComponentCommands);

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/FakeEventStore.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/FakeEventStore.java
@@ -76,7 +76,7 @@ public class FakeEventStore implements EventStorageEngine {
     }
 
     @Override
-    public void query(long minToken, long minTimestamp, Predicate<EventWithToken> consumer) {
+    public void query(QueryOptions queryOptions, Predicate<EventWithToken> consumer) {
 
     }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserverTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserverTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017-2020 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.localstorage.query;
+
+import io.axoniq.axonserver.grpc.event.Event;
+import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
+import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
+import io.axoniq.axonserver.localstorage.AggregateReader;
+import io.axoniq.axonserver.localstorage.DefaultEventDecorator;
+import io.axoniq.axonserver.localstorage.EventStreamReader;
+import io.axoniq.axonserver.localstorage.EventWriteStorage;
+import io.axoniq.axonserver.localstorage.SerializedEvent;
+import io.grpc.stub.StreamObserver;
+import org.junit.*;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Marc Gathier
+ */
+public class QueryEventsRequestStreamObserverTest {
+
+    private QueryEventsRequestStreamObserver testSubject;
+    private final EventStreamReader eventStreamReader = mock(EventStreamReader.class);
+    private final AggregateReader aggregateReader = mock(AggregateReader.class);
+    private final CompletableFuture<List<QueryEventsResponse>> completableResult = new CompletableFuture<>();
+
+    @Before
+    public void setUp() throws Exception {
+        EventWriteStorage eventWriteStorage = mock(EventWriteStorage.class);
+        StreamObserver<QueryEventsResponse> responseObserver = new StreamObserver<QueryEventsResponse>() {
+            private List<QueryEventsResponse> responses = new LinkedList<>();
+
+            @Override
+            public void onNext(QueryEventsResponse queryEventsResponse) {
+                responses.add(queryEventsResponse);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                completableResult.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                completableResult.complete(responses);
+            }
+        };
+
+        testSubject = new QueryEventsRequestStreamObserver(eventWriteStorage,
+                                                           eventStreamReader,
+                                                           aggregateReader,
+                                                           100,
+                                                           1000,
+                                                           new DefaultEventDecorator(),
+                                                           responseObserver);
+    }
+
+    @Test
+    public void onNext() throws InterruptedException, ExecutionException, TimeoutException {
+        doAnswer(invocation -> {
+            String aggregateId = invocation.getArgument(0);
+            Consumer<SerializedEvent> consumer = invocation.getArgument(3);
+            for (int i = 0; i < 10; i++) {
+                Event event = Event.newBuilder().setAggregateSequenceNumber(i).setAggregateIdentifier(aggregateId)
+                                   .build();
+                consumer.accept(new SerializedEvent(event));
+            }
+            return null;
+        }).when(aggregateReader).readEvents(anyString(), anyBoolean(), anyLong(), any(Consumer.class));
+        testSubject.onNext(QueryEventsRequest.newBuilder()
+                                             .setQuery("aggregateIdentifier = \"12345\"")
+                                             .setNumberOfPermits(1000)
+                                             .build());
+
+        List<QueryEventsResponse> responses = completableResult.get(2, TimeUnit.SECONDS);
+        assertEquals(12, responses.size());
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/HttpStreamingQueryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/HttpStreamingQueryTest.java
@@ -174,7 +174,7 @@ public class HttpStreamingQueryTest {
         emitter.onCompletion(latch::countDown);
 
         emitter.onTimeout(latch::countDown);
-        testSubject.query(Topology.DEFAULT_CONTEXT, "aggregateIdentifier = \"demo\" | limit( 10)",
+        testSubject.query(Topology.DEFAULT_CONTEXT, "aggregateIdentifier contains \"demo\" | limit( 10)",
                           QueryEventsRequestStreamObserver.TIME_WINDOW_CUSTOM, true, false,
                           "token", emitter);
 


### PR DESCRIPTION
added some optimizations in ad-hoc query handling to stop scanning segments when the minimum token requested in the query was found and to use an index when performing a query that filters on the aggregate id.
added options in UI to receive live updates and to force reading from the leader (both disabled by default) to reduce the accidental load caused by ad-hoc queries.
added option in UI to limit the time window for the query, defaults to one hour.
added popup in UI with data for the row and easy copy to clipboard option.