### PR TITLE
Feature/admin token

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/AxonServerStandardAccessController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/AxonServerStandardAccessController.java
@@ -9,12 +9,16 @@
 
 package io.axoniq.axonserver;
 
+import io.axoniq.axonserver.config.AccessControlConfiguration;
 import io.axoniq.axonserver.config.MessagingPlatformConfiguration;
 import io.axoniq.axonserver.exception.InvalidTokenException;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.Set;
+
+import static io.axoniq.axonserver.rest.json.UserInfo.ROLE_ADMIN;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 
 /**
  * Created by marc on 7/17/2017.
@@ -44,10 +48,16 @@ public class AxonServerStandardAccessController implements AxonServerAccessContr
         if (!isTokenFromConfigFile(token)) {
             throw new InvalidTokenException();
         }
-        return Collections.emptySet();
+        return isAdminToken(token) ? singleton(ROLE_ADMIN) : emptySet();
+    }
+
+    private boolean isAdminToken(String token) {
+        return (token != null) && token.equals(messagingPlatformConfiguration.getAccesscontrol().getAdminToken());
     }
 
     private boolean isTokenFromConfigFile(String token) {
-        return messagingPlatformConfiguration.getAccesscontrol().getToken().equals(token);
+        AccessControlConfiguration config = messagingPlatformConfiguration.getAccesscontrol();
+
+        return (token != null) && (token.equals(config.getToken()) || token.equals(config.getAdminToken()));
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/config/AccessControlConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/AccessControlConfiguration.java
@@ -20,18 +20,26 @@ public class AccessControlConfiguration {
      * Indicates that access control is enabled for the server.
      */
     private boolean enabled;
+
     /**
      * Timeout for authenticated tokens.
      */
     private long cacheTtl = 30000;
+
     /**
      * Token used to authenticate Axon Server instances in a cluster (only used by Enterprise Edition)
      */
     private String internalToken;
+
     /**
      * Token to be used by client applications connecting to Axon Server (only used by Standard Edition)
      */
     private String token;
+
+    /**
+     * Alternative token to be used by the CLI, receiving ADMIN rights.
+     */
+    private String adminToken;
 
     public boolean isEnabled() {
         return enabled;
@@ -63,5 +71,13 @@ public class AccessControlConfiguration {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public String getAdminToken() {
+        return adminToken;
+    }
+
+    public void setAdminToken(String adminToken) {
+        this.adminToken = adminToken;
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/json/UserInfo.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/json/UserInfo.java
@@ -15,6 +15,9 @@ import java.util.Set;
  * @author Marc Gathier
  */
 public class UserInfo {
+    public static final String ROLE_ADMIN = "ADMIN";
+    public static final String ROLE_ADMIN_IN_ADMIN = "ADMIN@_admin";
+
     private final String user;
     private final Set<String> roles;
     private final boolean adminUser;
@@ -23,7 +26,7 @@ public class UserInfo {
     public UserInfo(String user, Set<String> roles) {
         this.user = user;
         this.roles = roles;
-        this.adminUser = roles.contains("ADMIN@_admin") || roles.contains("ADMIN");
+        this.adminUser = roles.contains(ROLE_ADMIN_IN_ADMIN) || roles.contains(ROLE_ADMIN);
     }
 
     public String getUser() {


### PR DESCRIPTION
Added a second token, using property "`axoniq.axonserver.accesscontrol.adminToken`" which provides Admin rights.

```
$ cd running-axon-server/local
$ ./axonserver-cli.jar users
Error processing command 'users' on 'http://localhost:8024/v1/public/users': HTTP/1.1 401  - {"timestamp":1597398846296,"status":401,"error":"Unauthorized","message":"Unauthorized","path":"/v1/public/users"}
 $ ./axonserver-cli.jar users -t token1
Name
$ ./axonserver-cli.jar users -t token2
Name
$ ./axonserver-cli.jar register-user -t token1 -u admin -p test -r ADMIN
Error processing command 'register-user' on 'http://localhost:8024/v1/users': HTTP/1.1 403  - {"timestamp":1597398881044,"status":403,"error":"Forbidden","message":"Forbidden","path":"/v1/users"}
$ ./axonserver-cli.jar register-user -t token2 -u admin -p test -r ADMIN
$ ./axonserver-cli.jar users -t token2
Name
admin
$
```