### PR TITLE
bugfix/search-query

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/HttpStreamingQuery.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/HttpStreamingQuery.java
@@ -102,6 +102,10 @@ public class HttpStreamingQuery {
                                 break;
                             case FILES_COMPLETED:
                                 emitCompleted();
+                                if (!liveUpdates) {
+                                    sseEmitter.complete();
+                                    stop();
+                                }
                                 break;
                             case DATA_NOT_SET:
                                 break;


### PR DESCRIPTION
Terminate SSE emitter when Done event is received and not in live events mode