### PR TITLE
Snapshot store reinitialization during install snapshot

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
@@ -193,6 +193,7 @@ public interface EventStorageEngine {
 
     /**
      * Returns the next token that will be used by the event store. Does not change the token.
+     *
      * @return the next token
      */
     long nextToken();
@@ -201,4 +202,12 @@ public interface EventStorageEngine {
      * Deletes all event data in the Event Store (Only intended for development environments).
      */
     void deleteAllEventData();
+
+    /**
+     * Deletes all event data in the Event Store and reinitialize it starting form the specified token.
+     *
+     * @param initialToken the first token to start from
+     */
+    default void reInitializeStore(long initialToken) {
+    }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -439,6 +439,29 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
         return null;
     }
 
+    /**
+     * Deletes all event data in the specified context's EventStore and reinitialize it starting form the specified
+     * token.
+     *
+     * @param context    the context of the store to reinitialize
+     * @param firstToken the first token to start from
+     */
+    public void reInitializeSnapshotStore(String context, long firstToken) {
+        workersMap.computeIfAbsent(context, this::openIfExist);
+        workers(context).snapshotStorageEngine.reInitializeStore(firstToken);
+    }
+
+    /**
+     * Returns the first snapshot for the specified context.
+     *
+     * @param context the context of the snapshot event store.
+     * @return the first snapshot for the specified context.
+     */
+    public long getFirstSnapshot(String context) {
+        workersMap.computeIfAbsent(context, this::openIfExist);
+        return workers(context).snapshotStorageEngine.getFirstToken();
+    }
+
     public long getLastSnapshot(String context) {
         workersMap.computeIfAbsent(context, this::openIfExist);
         return workers(context).snapshotStorageEngine.getLastToken();

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/SegmentBasedEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/SegmentBasedEventStore.java
@@ -241,8 +241,12 @@ public abstract class SegmentBasedEventStore implements EventStorageEngine {
 
     @Override
     public long getFirstToken() {
-        if( next != null) return next.getFirstToken();
-        if( getSegments().isEmpty() ) return -1;
+        if (next != null && !next.getSegments().isEmpty()) {
+            return next.getFirstToken();
+        }
+        if (getSegments().isEmpty()) {
+            return -1;
+        }
         return getSegments().last();
     }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStoreTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStoreTest.java
@@ -162,6 +162,22 @@ public class PrimaryEventStoreTest {
         assertEquals(-1, testSubject.getLastToken());
 
         storeEvent();
-        assertEquals(0,testSubject.getLastToken());
+        assertEquals(0, testSubject.getLastToken());
+    }
+
+    @Test
+    public void reinitializeStoreFromAToken() throws InterruptedException {
+        setupEvents(5, 20);
+        assertEquals(1, testSubject.getSegments().size());
+        assertEquals(0, testSubject.getFirstToken());
+        assertEquals(99, testSubject.getLastToken());
+        testSubject.reInitializeStore(10);
+        assertEquals(1, testSubject.getSegments().size());
+        assertEquals(10, testSubject.getFirstToken());
+        assertEquals(9, testSubject.getLastToken());
+        setupEvents(5, 20);
+        assertEquals(1, testSubject.getSegments().size());
+        assertEquals(10, testSubject.getFirstToken());
+        assertEquals(109, testSubject.getLastToken());
     }
 }


### PR DESCRIPTION
Fix install snapshot when follower last stored snapshot is lower than the first snapshot in the leader.