### PR TITLE
Take context into account when selecting command destination

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandRegistrationCache.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandRegistrationCache.java
@@ -193,7 +193,7 @@ public class CommandRegistrationCache {
      */
     public CommandHandler getHandlerForCommand(String context, Command request, String routingKey) {
         String command = request.getName();
-        Set<ClientStreamIdentification> candidates = getCandidates(request);
+        Set<ClientStreamIdentification> candidates = getCandidates(context, request);
         if (candidates.isEmpty()) {
             return null;
         }
@@ -210,10 +210,11 @@ public class CommandRegistrationCache {
                 .orElse(null);
     }
 
-    private Set<ClientStreamIdentification> getCandidates(Command command) {
+    private Set<ClientStreamIdentification> getCandidates(String context, Command command) {
 
         Set<ClientStreamIdentification> candidates = registrationsPerClient.entrySet()
                                                                            .stream()
+                                                                           .filter(entry -> context.equals(entry.getKey().getContext()))
                                                                            .filter(entry -> entry
                                                                                    .getValue()
                                                                                    .containsKey(

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandRegistrationCacheTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandRegistrationCacheTest.java
@@ -74,6 +74,16 @@ public class CommandRegistrationCacheTest {
     }
 
     @Test
+    public void singleDestinationShortcutTakesContextIntoAccount() {
+        registrationCache.add("contextBCommand", new DirectCommandHandler(streamObserver1,new ClientStreamIdentification("otherContext",
+                                                                                                                         "client1" ),
+                                                                          "client1", "component"));
+
+        assertNotNull(registrationCache.getHandlerForCommand("otherContext", Command.newBuilder().setName("contextBCommand").build(), "irrelevant"));
+        assertNull(registrationCache.getHandlerForCommand(Topology.DEFAULT_CONTEXT, Command.newBuilder().setName("contextBCommand").build(), "irrelevant"));
+    }
+
+    @Test
     public void removeLastCommandSubscription() {
         registrationCache.remove(new ClientStreamIdentification(Topology.DEFAULT_CONTEXT, "client1"), "command1");
         assertFalse(registrationCache.getAll().containsKey(new DirectCommandHandler(streamObserver1,


### PR DESCRIPTION
This wasn't the case when only a single suitable destination could be found. In that case, the destination was chosen, without validating its context.