### PR TITLE
Fixed issues with null expressions in ad-hoc query

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/ExpressionResult.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/ExpressionResult.java
@@ -44,6 +44,10 @@ public interface ExpressionResult extends Comparable<ExpressionResult> {
         return null;
     }
 
+    default boolean isNull() {
+        return getValue() == null;
+    }
+
     default boolean isNonNull() {
         return getValue() != null;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
@@ -454,8 +454,8 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
         }
 
         private QueryValue wrap(ExpressionResult expressionResult) {
-            if (expressionResult == null) {
-                return QueryValue.newBuilder().build();
+            if (expressionResult == null || expressionResult.isNull()) {
+                return QueryValue.getDefaultInstance();
             }
             if (expressionResult instanceof TimestampExpressionResult) {
                 return QueryValue.newBuilder().setTextValue(expressionResult.toString()).build();

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/BooleanExpressionResult.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/BooleanExpressionResult.java
@@ -47,6 +47,11 @@ public class BooleanExpressionResult implements ExpressionResult {
     }
 
     @Override
+    public boolean isNull() {
+        return false;
+    }
+
+    @Override
     public boolean isNonNull() {
         return true;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/EventExpressionResult.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/EventExpressionResult.java
@@ -99,6 +99,11 @@ public class EventExpressionResult implements AbstractMapExpressionResult {
     }
 
     @Override
+    public boolean isNull() {
+        return event == null;
+    }
+
+    @Override
     public boolean isNonNull() {
         return event != null;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/ListExpressionResult.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/ListExpressionResult.java
@@ -50,6 +50,11 @@ public class ListExpressionResult implements ExpressionResult {
     }
 
     @Override
+    public boolean isNull() {
+        return results == null;
+    }
+
+    @Override
     public boolean isNonNull() {
         return results != null;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/MapExpressionResult.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/MapExpressionResult.java
@@ -43,6 +43,11 @@ public class MapExpressionResult implements AbstractMapExpressionResult {
     }
 
     @Override
+    public boolean isNull() {
+        return false;
+    }
+
+    @Override
     public boolean isNonNull() {
         return true;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/NullExpressionResult.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/NullExpressionResult.java
@@ -30,6 +30,11 @@ public class NullExpressionResult implements ExpressionResult {
     }
 
     @Override
+    public boolean isNull() {
+        return true;
+    }
+
+    @Override
     public boolean isNonNull() {
         return false;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/NumericExpressionResult.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/NumericExpressionResult.java
@@ -46,6 +46,11 @@ public class NumericExpressionResult implements ExpressionResult {
     }
 
     @Override
+    public boolean isNull() {
+        return value == null;
+    }
+
+    @Override
     public boolean isNonNull() {
         return value != null;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/StringExpressionResult.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/result/StringExpressionResult.java
@@ -39,6 +39,11 @@ public class StringExpressionResult implements ExpressionResult {
     }
 
     @Override
+    public boolean isNull() {
+        return value == null;
+    }
+
+    @Override
     public boolean isNonNull() {
         return value != null;
     }


### PR DESCRIPTION
When executing expressions that resulted in a null value, processing the results may fail and the process would stop, while in the UI it seems to continue indefinitely.
This commit contains some safeguards around null values to ensure they are reported properly.