### PR TITLE
Hot fix/subquery initial result

### DIFF
--- a/axonserver/README.txt
+++ b/axonserver/README.txt
@@ -3,6 +3,10 @@ This is the Axon Server Standard Edition, version 4.4
 For information about the Axon Framework and Axon Server,
 visit https://docs.axoniq.io.
 
+Release Notes for version 4.4.7
+-------------------------------
+* Improvement for subscription query: initial result are now provided by a single instance per component
+
 Release Notes for version 4.4.6
 -------------------------------
 * Fix for processor information showing information on disconnected applications


### PR DESCRIPTION
Fix #223.
Now the initial result request for subscription query is dispatched only to one client instance for each component. Added also unit tests.
