### PR TITLE
Optimization for reading index.

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/AppendOnlyList.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/AppendOnlyList.java
@@ -29,16 +29,13 @@ import javax.annotation.Nonnull;
  * @author Marc Gathier
  * @since 4.5
  */
+@SuppressWarnings("squid:S2160")
 public class AppendOnlyList<T> extends AbstractList<T> {
 
     public static final String LIST_IS_APPEND_ONLY = "List is append only";
     private final Node<T> head;
     private final AtomicInteger size = new AtomicInteger();
     private final AtomicReference<Node<T>> last = new AtomicReference<>();
-
-    public AppendOnlyList() {
-        this(Collections.emptyList());
-    }
 
     public AppendOnlyList(List<T> values) {
         head = new Node<>(values);
@@ -94,16 +91,6 @@ public class AppendOnlyList<T> extends AbstractList<T> {
     @Override
     public boolean removeIf(Predicate<? super T> filter) {
         throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return super.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
     }
 
     public T last() {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/AppendOnlyList.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/AppendOnlyList.java
@@ -146,7 +146,7 @@ public class AppendOnlyList<T> extends AbstractList<T> {
 
             @Override
             public void remove() {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
             }
         };
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/AppendOnlyList.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/AppendOnlyList.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2017-2021 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.localstorage.file;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import javax.annotation.Nonnull;
+
+/**
+ * Append-only list. List that only supports adding entries at the end, all other operations that attempt to
+ * change the content of the list throw an {@link UnsupportedOperationException}.
+ *
+ * @author Marc Gathier
+ * @since 4.5
+ */
+public class AppendOnlyList<T> extends AbstractList<T> {
+
+    public static final String LIST_IS_APPEND_ONLY = "List is append only";
+    private final Node<T> head;
+    private final AtomicInteger size = new AtomicInteger();
+    private final AtomicReference<Node<T>> last = new AtomicReference<>();
+
+    public AppendOnlyList() {
+        this(Collections.emptyList());
+    }
+
+    public AppendOnlyList(List<T> values) {
+        head = new Node<>(values);
+        last.set(head);
+        size.set(values.size());
+    }
+
+    @Override
+    public void add(int index, T element) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends T> c) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public T remove(int index) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public void sort(Comparator<? super T> c) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public T set(int index, T element) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    protected void removeRange(int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public void replaceAll(UnaryOperator<T> operator) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super T> filter) {
+        throw new UnsupportedOperationException(LIST_IS_APPEND_ONLY);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    public T last() {
+        List<? extends T> lastValues = last.get().values;
+        return lastValues.get(lastValues.size() - 1);
+    }
+
+    public boolean isEmpty() {
+        return size.get() == 0;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<T> iterator() {
+        int sizeAtStart = size.get();
+        return new Iterator<T>() {
+            Node<T> currentNode = head;
+            int index = 0;
+            int count = 0;
+
+            @Override
+            public boolean hasNext() {
+                return count < sizeAtStart;
+            }
+
+            @Override
+            public T next() {
+                T value = null;
+                if (currentNode.size() > index) {
+                    value = currentNode.get(index);
+                    index++;
+                    count++;
+                } else {
+                    currentNode = currentNode.next;
+                    index = 0;
+                    value = next();
+                }
+                return value;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return size.get();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> values) {
+        last.updateAndGet(l -> l.add(values));
+        size.addAndGet(values.size());
+        return true;
+    }
+
+    @Override
+    public boolean add(T value) {
+        return addAll(Collections.singletonList(value));
+    }
+
+    @Override
+    public T get(int index) {
+        int pos = 0;
+        if (index < 0 || index >= size.get()) {
+            throw new IndexOutOfBoundsException(String.format("%d: index out of bounds [0..%d]",
+                                                              index,
+                                                              size.get() - 1));
+        }
+        Node<T> node = head;
+        while (pos + node.size() <= index) {
+            pos += node.size();
+            node = node.next;
+        }
+        return node.get(index - pos);
+    }
+
+    private static class Node<T> {
+
+        private final List<? extends T> values;
+        private Node<T> next;
+
+        private Node(List<? extends T> values) {
+            this.values = values;
+        }
+
+        private Node<T> add(Collection<? extends T> values) {
+            this.next = new Node<>(asList(values));
+            return this.next;
+        }
+
+        private List<? extends T> asList(Collection<? extends T> values) {
+            if (values instanceof List) {
+                return (List<? extends T>) values;
+            }
+            return new ArrayList<>(values);
+        }
+
+        public int size() {
+            return values.size();
+        }
+
+        public T get(int index) {
+            return values.get(index);
+        }
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntries.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntries.java
@@ -10,8 +10,8 @@
 package io.axoniq.axonserver.localstorage.file;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Implementation of the {@link IndexEntries} used by the {@link StandardIndexManager}.
@@ -21,7 +21,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class StandardIndexEntries implements IndexEntries {
 
-    protected final List<Integer> entries;
+    private final AppendOnlyList<Integer> entries;
     private final long firstSequenceNumber;
 
     /**
@@ -29,7 +29,7 @@ public class StandardIndexEntries implements IndexEntries {
      * @param firstSequenceNumber first sequence number
      */
     public StandardIndexEntries(long firstSequenceNumber) {
-        this(firstSequenceNumber, new CopyOnWriteArrayList<>());
+        this(firstSequenceNumber, Collections.emptyList());
     }
 
     /**
@@ -38,7 +38,7 @@ public class StandardIndexEntries implements IndexEntries {
      * @param entries the positions of the aggregate
      */
     public StandardIndexEntries(long firstSequenceNumber, List<Integer> entries) {
-        this.entries = new CopyOnWriteArrayList<>(entries);
+        this.entries = new AppendOnlyList<>(entries);
         this.firstSequenceNumber = firstSequenceNumber;
     }
 
@@ -99,7 +99,7 @@ public class StandardIndexEntries implements IndexEntries {
         if (isEmpty()) {
             return -1;
         }
-        return entries.get(entries.size() - 1);
+        return entries.last();
     }
 
     /**

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntriesSerializer.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntriesSerializer.java
@@ -14,6 +14,8 @@ import org.mapdb.DataOutput2;
 import org.mapdb.Serializer;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
 
 /**
@@ -64,10 +66,10 @@ public class StandardIndexEntriesSerializer implements Serializer<IndexEntries> 
     public IndexEntries deserialize(@Nonnull DataInput2 input, int available) throws IOException {
         int count = input.unpackInt();
         long sequenceNumber = input.unpackLong();
-        StandardIndexEntries standardIndexEntries = new StandardIndexEntries(sequenceNumber);
+        List<Integer> entries = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
-            standardIndexEntries.add(input.unpackInt());
+            entries.add(input.unpackInt());
         }
-        return standardIndexEntries;
+        return new StandardIndexEntries(sequenceNumber, entries);
     }
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntriesTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntriesTest.java
@@ -8,6 +8,8 @@ import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
 
@@ -48,5 +50,22 @@ public class StandardIndexEntriesTest {
             System.out.println(expectedPosition);
         }
         running.set(false);
+    }
+
+    @Test
+    public void addAndLoopPerformance() {
+        StandardIndexEntries standardIndexEntries = new StandardIndexEntries(10);
+        standardIndexEntries.last();
+        long before = System.currentTimeMillis();
+        IntStream.range(0, 200_000).forEach(i -> standardIndexEntries.add(new IndexEntry(1, i, 1)));
+        assertTrue("Added entries - " + (System.currentTimeMillis() - before),
+                   System.currentTimeMillis() - before < 250);
+        AtomicLong total = new AtomicLong();
+        before = System.currentTimeMillis();
+        standardIndexEntries.positions().forEach(total::addAndGet);
+        assertTrue("Iterate entries - " + (System.currentTimeMillis() - before),
+                   System.currentTimeMillis() - before < 250);
+        Assert.assertEquals(1998, (int) standardIndexEntries.positions().get(1998));
+        Assert.assertEquals(4000, (int) standardIndexEntries.positions().get(4000));
     }
 }


### PR DESCRIPTION
The usage of CopyOnWriteArrayList fixed the concurrency issue accessing the index, but also created a bottleneck in writing speed. This PR improves the performance in loading index from files and during index initialization. It doesn't solve the problem that can in case of heavy load of events.