### PR TITLE
Calculation of active subscription queries in cluster

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/metric/ApplicationSubscriptionMetricRegistry.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/metric/ApplicationSubscriptionMetricRegistry.java
@@ -13,6 +13,7 @@ import io.axoniq.axonserver.applicationevents.SubscriptionQueryEvents;
 import io.axoniq.axonserver.metric.BaseMetricName;
 import io.axoniq.axonserver.metric.ClusterMetric;
 import io.axoniq.axonserver.metric.CounterMetric;
+import io.axoniq.axonserver.metric.GaugeMetric;
 import io.axoniq.axonserver.metric.MeterFactory;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tags;
@@ -54,7 +55,8 @@ public class ApplicationSubscriptionMetricRegistry {
         Counter updates = updatesMetric(componentName, context);
         return new HubSubscriptionMetrics(
                 Tags.of(MeterFactory.CONTEXT, context, TAG_COMPONENT, componentName),
-                new CounterMetric(activeSubscriptionsMetricName(componentName, context), () -> (long) active.get()),
+                new GaugeMetric(BaseMetricName.AXON_APPLICATION_SUBSCRIPTION_ACTIVE.metric(),
+                                () -> (double) active.get()),
                 new CounterMetric(total.getId().getName(), () -> (long) total.count()),
                 new CounterMetric(updates.getId().getName(), () -> (long) updates.count()),
                 clusterMetricProvider);

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/metric/GlobalSubscriptionMetricRegistry.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/metric/GlobalSubscriptionMetricRegistry.java
@@ -14,6 +14,7 @@ import io.axoniq.axonserver.message.query.subscription.SubscriptionMetrics;
 import io.axoniq.axonserver.metric.BaseMetricName;
 import io.axoniq.axonserver.metric.ClusterMetric;
 import io.axoniq.axonserver.metric.CounterMetric;
+import io.axoniq.axonserver.metric.GaugeMetric;
 import io.axoniq.axonserver.metric.MeterFactory;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tags;
@@ -56,9 +57,9 @@ public class GlobalSubscriptionMetricRegistry implements Supplier<SubscriptionMe
     @Override
     public HubSubscriptionMetrics get() {
         return new HubSubscriptionMetrics(Tags.empty(),
-                                          new CounterMetric(BaseMetricName.AXON_GLOBAL_SUBSCRIPTION_ACTIVE.metric(),
-                                                            () -> (long) active.get()),
-                                          new CounterMetric(total.getId().getName(), () -> (long)total.count()),
+                                          new GaugeMetric(BaseMetricName.AXON_GLOBAL_SUBSCRIPTION_ACTIVE.metric(),
+                                                          () -> (double) active.get()),
+                                          new CounterMetric(total.getId().getName(), () -> (long) total.count()),
                                           new CounterMetric(updates.getId().getName(), () -> (long) updates.count()),
                                           clusterMetricCollector);
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/metric/HubSubscriptionMetrics.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/metric/HubSubscriptionMetrics.java
@@ -13,6 +13,7 @@ import io.axoniq.axonserver.message.query.subscription.SubscriptionMetrics;
 import io.axoniq.axonserver.metric.ClusterMetric;
 import io.axoniq.axonserver.metric.CompositeMetric;
 import io.axoniq.axonserver.metric.CounterMetric;
+import io.axoniq.axonserver.metric.GaugeMetric;
 import io.axoniq.axonserver.serializer.Media;
 import io.micrometer.core.instrument.Tags;
 
@@ -28,7 +29,7 @@ public class HubSubscriptionMetrics implements SubscriptionMetrics {
     private final ClusterMetric activeSubscriptions;
     private final ClusterMetric updates;
 
-    public HubSubscriptionMetrics(Tags tags, CounterMetric active, CounterMetric total, CounterMetric updates,
+    public HubSubscriptionMetrics(Tags tags, GaugeMetric active, CounterMetric total, CounterMetric updates,
                                   BiFunction<String, Tags, ClusterMetric> clusterRegistry) {
         this(
                 new CompositeMetric(total, clusterRegistry.apply(total.getName(), tags)),
@@ -52,7 +53,7 @@ public class HubSubscriptionMetrics implements SubscriptionMetrics {
 
     @Override
     public Long activesCount() {
-        return activeSubscriptions.count();
+        return (long) activeSubscriptions.value();
     }
 
     @Override

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/metric/QuerySubscriptionMetricRegistry.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/subscription/metric/QuerySubscriptionMetricRegistry.java
@@ -13,6 +13,7 @@ import io.axoniq.axonserver.applicationevents.SubscriptionQueryEvents;
 import io.axoniq.axonserver.metric.BaseMetricName;
 import io.axoniq.axonserver.metric.ClusterMetric;
 import io.axoniq.axonserver.metric.CounterMetric;
+import io.axoniq.axonserver.metric.GaugeMetric;
 import io.axoniq.axonserver.metric.MeterFactory;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tags;
@@ -56,8 +57,8 @@ public class QuerySubscriptionMetricRegistry  {
         Counter updates = updatesMetric(component,query, context);
         return new HubSubscriptionMetrics(
                 Tags.of(MeterFactory.CONTEXT, context, TAG_QUERY, query),
-                new CounterMetric(activeSubscriptionsMetricName(query, context), () -> (long) active.get()),
-                new CounterMetric(total.getId().getName(), () -> (long)total.count()),
+                new GaugeMetric(BaseMetricName.AXON_QUERY_SUBSCRIPTION_ACTIVE.metric(), () -> (double) active.get()),
+                new CounterMetric(total.getId().getName(), () -> (long) total.count()),
                 new CounterMetric(updates.getId().getName(), () -> (long) updates.count()), clusterMetricProvider);
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/metric/GaugeMetric.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/metric/GaugeMetric.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.metric;
+
+import java.util.function.Supplier;
+
+/**
+ * Created by Sara Pellegrini on 22/06/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class GaugeMetric implements ClusterMetric {
+
+    private final String name;
+    private final Supplier<Double> valueProvider;
+
+    public GaugeMetric(String name, Supplier<Double> valueProvider) {
+        this.name = name;
+        this.valueProvider = valueProvider;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public double min() {
+        return 0;
+    }
+
+    @Override
+    public double max() {
+        return 0;
+    }
+
+    @Override
+    public double mean() {
+        return 0;
+    }
+
+    @Override
+    public double value() {
+        return valueProvider.get();
+    }
+}


### PR DESCRIPTION
Changed name of the active query metric for cluster to basename.
Changed type to GaugeMetric as it is backed by a Gauge (which has the value in the value() field).