### PR TITLE
Correctly handle a FQDN set as hostname in the OS

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/config/MessagingPlatformConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/MessagingPlatformConfiguration.java
@@ -259,6 +259,19 @@ public class MessagingPlatformConfiguration {
     }
 
     public String getDomain() {
+        if (domain == null) {
+            try {
+                String systemHostname = systemInfoProvider.getHostName();
+                int firstDot = systemHostname.indexOf('.');
+                if (firstDot != -1) {
+                    domain = systemHostname.substring(firstDot + 1);
+                } else {
+                    domain = "";
+                }
+            } catch (UnknownHostException e) {
+                logger.warn("Could not determine hostname from inet address: {}", e.getMessage());
+            }
+        }
         return domain;
     }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/config/MessagingPlatformConfigurationTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/config/MessagingPlatformConfigurationTest.java
@@ -9,67 +9,138 @@
 
 package io.axoniq.axonserver.config;
 
-import org.junit.*;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.net.UnknownHostException;
+import java.lang.invoke.MethodHandles;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Marc Gathier
  */
 public class MessagingPlatformConfigurationTest {
-    private MessagingPlatformConfiguration testSubject;
 
-    @Test
-    public void getHostname() {
-        testSubject = new MessagingPlatformConfiguration(new SystemInfoProvider() {
-            @Override
-            public int getPort() {
-                return 0;
-            }
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-            @Override
-            public String getHostName() throws UnknownHostException {
-                return "test.axoniq.io";
-            }
-        });
-        assertEquals("test.axoniq.io", testSubject.getHostname());
-    }
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_HOSTNAME = "hostname";
+    private static final String FIELD_DOMAIN = "domain";
+    private static final String FIELD_FQDN = "fqdn";
 
-    @Test
-    public void getHostnameWithDomainSet() {
-        testSubject = new MessagingPlatformConfiguration(new SystemInfoProvider() {
-            @Override
-            public int getPort() {
-                return 0;
-            }
+    private static final String NOT_SET = null;
+    private static final String DONT_TEST = "DONTTEST";
+    private static final String SET_TO_EMPTY = "";
+    private static final String TEST_AXONIQ_IO = "test.axoniq.io";
+    private static final String TEST = "test";
+    private static final String AXONIQ_IO = "axoniq.io";
+    private static final String AXONSERVER_DEMO_IO = "axonserver.demo.io";
+    private static final String AXONSERVER = "axonserver";
+    private static final String DEMO_IO = "demo.io";
+    private static final String AXONSERVER_AXONIQ_IO = "axonserver.axoniq.io";
 
+    private MessagingPlatformConfiguration buildConfigWithHostname(final String name,
+                                                                   final String hostname, final String domain,
+                                                                   final String systemHostname) {
+        MessagingPlatformConfiguration result = new MessagingPlatformConfiguration(new SystemInfoProvider() {
             @Override
-            public String getHostName() throws UnknownHostException {
-                return "test.axoniq.io";
+            public String getHostName() {
+                return systemHostname;
             }
         });
-        testSubject.setDomain("axoniq.io");
-        assertEquals("test", testSubject.getHostname());
-        assertEquals("test.axoniq.io", testSubject.getFullyQualifiedHostname());
+        result.setName(name);
+        result.setHostname(hostname);
+        result.setDomain(domain);
+        result.postConstruct();
+
+        return result;
     }
+
+    private final static NameTest[] tests = {
+            new NameTest("Name from hostname",
+                    "When no name is set, the name is taken from the hostname.",
+                    NOT_SET, NOT_SET, NOT_SET, TEST_AXONIQ_IO,
+                    TEST, DONT_TEST, DONT_TEST, DONT_TEST),
+            new NameTest("Name trumps hostname",
+                    "When a name is set, it is used instead of the hostname",
+                    AXONSERVER, NOT_SET, NOT_SET, TEST_AXONIQ_IO,
+                    AXONSERVER, DONT_TEST, DONT_TEST, DONT_TEST),
+            new NameTest("Hostname from OS",
+                    "If nothing is set, the hostname and domain are taken from the OS.",
+                    NOT_SET, NOT_SET, NOT_SET, TEST,
+                    DONT_TEST, TEST, SET_TO_EMPTY, TEST),
+            new NameTest("FQDN from OS",
+                    "If nothing is set, the hostname and domain are taken from the OS.",
+                    NOT_SET, NOT_SET, NOT_SET, TEST_AXONIQ_IO,
+                    DONT_TEST, TEST, AXONIQ_IO, TEST_AXONIQ_IO),
+            new NameTest("Explicit hostname",
+                    "If hostname is set, it is used instead of that from the OS.",
+                    NOT_SET, AXONSERVER, NOT_SET, TEST_AXONIQ_IO,
+                    DONT_TEST, AXONSERVER, AXONIQ_IO, AXONSERVER_AXONIQ_IO),
+            new NameTest("Explicitly empty domain",
+                    "If domain is set as empty string, it is used instead of that from the OS.",
+                    NOT_SET, AXONSERVER, SET_TO_EMPTY, TEST_AXONIQ_IO,
+                    DONT_TEST, AXONSERVER, SET_TO_EMPTY, AXONSERVER),
+            new NameTest("Explicitly domain",
+                    "If domain is set, it is used instead of that from the OS.",
+                    NOT_SET, AXONSERVER, DEMO_IO, TEST_AXONIQ_IO,
+                    DONT_TEST, AXONSERVER, DEMO_IO, AXONSERVER_DEMO_IO)
+    };
+
+    private void testEquals(String name, String message, String fieldName, String expected, String actual) {
+        if (!DONT_TEST.equals(expected)) {
+            assertEquals(name + ": " + message + " [" + fieldName + "]", expected, actual);
+        }
+    }
+
+    private void runTest(NameTest test) {
+        logger.debug("Performing test '{}'", test.testName);
+
+        final MessagingPlatformConfiguration conf = buildConfigWithHostname(
+                test.name, test.hostname, test.domain, test.systemHostname);
+
+        testEquals(test.testName, test.testMessage, FIELD_NAME, test.expectedName, conf.getName());
+        testEquals(test.testName, test.testMessage, FIELD_HOSTNAME, test.expectedHostname, conf.getHostname());
+        testEquals(test.testName, test.testMessage, FIELD_DOMAIN, test.expectedDomain, conf.getDomain());
+        testEquals(test.testName, test.testMessage, FIELD_FQDN, test.expectedFQDN, conf.getFullyQualifiedHostname());
+    }
+
+    // How we define the node's name
 
     @Test
-    public void getHostnameWithBlankDomain() {
-        testSubject = new MessagingPlatformConfiguration(new SystemInfoProvider() {
-            @Override
-            public int getPort() {
-                return 0;
-            }
-
-            @Override
-            public String getHostName() throws UnknownHostException {
-                return "test";
-            }
-        });
-        testSubject.setDomain("");
-        assertEquals("test", testSubject.getFullyQualifiedHostname());
-        assertEquals("test", testSubject.getFullyQualifiedInternalHostname());
+    public void testNames() {
+        for (NameTest test : tests) {
+            runTest(test);
+        }
     }
+
+    private static class NameTest {
+        private final String testName;
+        private final String testMessage;
+        private final String name;
+        private final String hostname;
+        private final String domain;
+        private final String systemHostname;
+        private final String expectedName;
+        private final String expectedHostname;
+        private final String expectedDomain;
+        private final String expectedFQDN;
+
+        private NameTest(String testName, String testMessage,
+                         String name, String hostname, String domain, String systemHostname,
+                         String expectedName, String expectedHostname, String expectedDomain, String expectedFQDN) {
+            this.testName = testName;
+            this.testMessage = testMessage;
+            this.name = name;
+            this.hostname = hostname;
+            this.domain = domain;
+            this.systemHostname = systemHostname;
+            this.expectedName = expectedName;
+            this.expectedHostname = expectedHostname;
+            this.expectedDomain = expectedDomain;
+            this.expectedFQDN = expectedFQDN;
+        }
+    }
+
 }


### PR DESCRIPTION
The rules should be that the "`hostname`" property will only contain a hostname and never a FQDN. This prevents confusion between FQDN in the OS and only a domain set in the properties, plus probably several other combinations.