### PR TITLE
Read aggregate with max sequence number fix for snapshots

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/AggregateReader.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/AggregateReader.java
@@ -35,12 +35,11 @@ public class AggregateReader {
                            Consumer<SerializedEvent> eventConsumer) {
         long actualMinSequenceNumber = minSequenceNumber;
         if (useSnapshots) {
-            Optional<SerializedEvent> snapshot = snapshotReader.readSnapshot(aggregateId, minSequenceNumber);
+            Optional<SerializedEvent> snapshot = snapshotReader.readSnapshot(aggregateId,
+                                                                             minSequenceNumber,
+                                                                             maxSequenceNumber);
             if (snapshot.isPresent()) {
                 eventConsumer.accept(snapshot.get());
-                if (snapshot.get().getAggregateSequenceNumber() >= maxSequenceNumber) {
-                    return;
-                }
                 actualMinSequenceNumber = snapshot.get().asEvent().getAggregateSequenceNumber() + 1;
             }
         }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
@@ -100,7 +100,7 @@ public interface EventStorageEngine {
 
     /**
      * Retrieves the last event for a specific aggregate id with a sequence number higher than or equal to the given
-     * sequence number.
+     * {@code minSequenceNumber} and lower than the given {@code maxSequenceNumber}.
      * Returns empty optional if aggregate is not found or no event with higher sequence number is found.
      *
      * @param aggregateIdentifier the aggregate identifier
@@ -112,10 +112,12 @@ public interface EventStorageEngine {
 
 
     /**
-     * Find events for an aggregate and execute the consumer for each event. Stops when last event for aggregate is found.
-     * @param aggregateId the aggregate identifier
+     * Find events for an aggregate and execute the consumer for each event. Stops when last event for aggregate is
+     * found.
+     *
+     * @param aggregateId       the aggregate identifier
      * @param minSequenceNumber the first sequence number to retrieve
-     * @param maxSequenceNumber the last sequence number to retrieve (exlusive)
+     * @param maxSequenceNumber the last sequence number to retrieve (exclusive)
      * @param eventConsumer     the consumer to apply for each event
      */
     void processEventsPerAggregate(String aggregateId, long minSequenceNumber, long maxSequenceNumber, long minToken,

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
@@ -11,11 +11,8 @@ package io.axoniq.axonserver.localstorage;
 
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.EventWithToken;
-import org.springframework.boot.actuate.autoconfigure.system.DiskSpaceHealthIndicatorProperties;
-import org.springframework.boot.actuate.health.Health;
 import org.springframework.data.util.CloseableIterator;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -102,13 +99,16 @@ public interface EventStorageEngine {
     Registration registerCloseListener(Runnable listener);
 
     /**
-     * Retrieves the last event for a specific aggregate id with a sequence number higher than or equal to the given sequence number.
+     * Retrieves the last event for a specific aggregate id with a sequence number higher than or equal to the given
+     * sequence number.
      * Returns empty optional if aggregate is not found or no event with higher sequence number is found.
+     *
      * @param aggregateIdentifier the aggregate identifier
-     * @param minSequenceNumber the minimum sequence number
+     * @param minSequenceNumber   the minimum sequence number
+     * @param maxSequenceNumber   the last sequence number(exclusive)
      * @return optional containing the latest event
      */
-    Optional<SerializedEvent> getLastEvent(String aggregateIdentifier, long minSequenceNumber);
+    Optional<SerializedEvent> getLastEvent(String aggregateIdentifier, long minSequenceNumber, long maxSequenceNumber);
 
 
     /**

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/SnapshotReader.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/SnapshotReader.java
@@ -22,10 +22,10 @@ public class SnapshotReader {
         this.datafileManagerChain = datafileManagerChain;
     }
 
-    public Optional<SerializedEvent> readSnapshot(String aggregateId, long minSequenceNumber) {
-            return datafileManagerChain
-                    .getLastEvent(aggregateId, minSequenceNumber)
-                    .map(SerializedEvent::asSnapshot);
+    public Optional<SerializedEvent> readSnapshot(String aggregateId, long minSequenceNumber, long maxSequenceNumber) {
+        return datafileManagerChain
+                .getLastEvent(aggregateId, minSequenceNumber, maxSequenceNumber)
+                .map(SerializedEvent::asSnapshot);
     }
 
     public void streamByAggregateId(String aggregateId, long minSequenceNumber, long maxSequenceNumber, int maxResults, Consumer<SerializedEvent> eventConsumer) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/IndexManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/IndexManager.java
@@ -92,14 +92,14 @@ public interface IndexManager {
 
 
     /**
-     * Retrieves the last segment and position of an event for given aggregate. Returns null if aggregate is not
-     * found, or no event with sequence number greater than or equal to the minimum sequence number.
+     * Retrieves the index entries of the last segment containing the aggregate where the first sequence
+     * number of events/snapshots for the aggregate in the segment is lower than {@code maxSequenceNumber}.
      *
      * @param aggregateId       the aggregate identifier
-     * @param minSequenceNumber minimum sequence number of the event to find
-     * @return segment and position of the last event
+     * @param maxSequenceNumber maximum sequence number of the event to find (exclusive)
+     * @return segment and position of events for the aggregate in the given segment
      */
-    SegmentAndPosition lastEvent(String aggregateId, long minSequenceNumber);
+    SegmentIndexEntries lastIndexEntries(String aggregateId, long maxSequenceNumber);
 
     /**
      * Returns a stream of index related files that should be included in the backup

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/SegmentIndexEntries.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/SegmentIndexEntries.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017-2021 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.localstorage.file;
+
+/**
+ * @author Marc Gathier
+ */
+public class SegmentIndexEntries {
+
+    private final long segment;
+    private final IndexEntries indexEntries;
+
+    public SegmentIndexEntries(long segment, IndexEntries indexEntries) {
+        this.segment = segment;
+        this.indexEntries = indexEntries;
+    }
+
+    public long segment() {
+        return segment;
+    }
+
+    public IndexEntries indexEntries() {
+        return indexEntries;
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/AggregateReaderTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/AggregateReaderTest.java
@@ -21,8 +21,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.*;
-
 /**
  * @author Marc Gathier
  */
@@ -129,6 +127,18 @@ public class AggregateReaderTest {
 
         Assert.assertEquals(10, events.size());
         Assert.assertEquals("Demo", events.get(0).getAggregateType());
+    }
+
+    @Test
+    public void readEventsWithSnapshotAfterMax() {
+        List<Event> events = new ArrayList<>();
+        testSubject.readEvents("55", true, 0, 30, 0, event -> {
+            events.add(event.asEvent());
+        });
+
+        Assert.assertEquals(5, events.size());
+        Assert.assertEquals("Snapshot", events.get(0).getAggregateType());
+        Assert.assertEquals(25, events.get(0).getAggregateSequenceNumber());
     }
 
     @Test

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/FakeEventStore.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/FakeEventStore.java
@@ -47,7 +47,7 @@ public class FakeEventStore implements EventStorageEngine {
     }
 
     @Override
-    public Optional<SerializedEvent> getLastEvent(String aggregateId, long minSequenceNumber) {
+    public Optional<SerializedEvent> getLastEvent(String aggregateId, long minSequenceNumber, long maxSequenceNumber) {
         return Optional.empty();
     }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStoreTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStoreTest.java
@@ -450,7 +450,8 @@ public class LocalEventStoreTest {
         }
 
         @Override
-        public Optional<SerializedEvent> getLastEvent(String aggregateId, long minSequenceNumber) {
+        public Optional<SerializedEvent> getLastEvent(String aggregateId, long minSequenceNumber,
+                                                      long maxSequenceNumber) {
             return Optional.of(new SerializedEvent(events[events.length - 1]));
         }
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/MultipleSnapshotSegments.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/MultipleSnapshotSegments.java
@@ -73,7 +73,7 @@ public class MultipleSnapshotSegments {
         testSubject.init(true);
         Optional<SerializedEvent> snapshot = testSubject.getLastEvent(
                 "Aggregate-325",
-                0);
+                0, Long.MAX_VALUE);
         assertTrue(snapshot.isPresent());
         assertEquals(1, snapshot.get().getAggregateSequenceNumber());
     }
@@ -83,7 +83,7 @@ public class MultipleSnapshotSegments {
         testSubject.init(true);
         Optional<SerializedEvent> snapshot = testSubject.getLastEvent(
                 "Aggregate-360",
-                0);
+                0, Long.MAX_VALUE);
         assertTrue(snapshot.isPresent());
         assertEquals(1, snapshot.get().getAggregateSequenceNumber());
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/rest/HttpStreamingQueryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/rest/HttpStreamingQueryTest.java
@@ -59,7 +59,8 @@ public class HttpStreamingQueryTest {
             }
 
             @Override
-            public Optional<SerializedEvent> getLastEvent(String aggregateId, long minSequenceNumber) {
+            public Optional<SerializedEvent> getLastEvent(String aggregateId, long minSequenceNumber,
+                                                          long maxSequenceNumber) {
                 return Optional.empty();
             }
 


### PR DESCRIPTION
AggregateReader must not return a snapshot that has a higher sequence number than or equal to the specified max sequence number.