### PR TITLE
Reduced memory usage for the AppendOnlyList

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntries.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntries.java
@@ -10,7 +10,6 @@
 package io.axoniq.axonserver.localstorage.file;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -29,15 +28,16 @@ public class StandardIndexEntries implements IndexEntries {
      * @param firstSequenceNumber first sequence number
      */
     public StandardIndexEntries(long firstSequenceNumber) {
-        this(firstSequenceNumber, Collections.emptyList());
+        this(firstSequenceNumber, new Integer[0]);
     }
 
     /**
      * Initializes the object with given entries and {@code firstSequenceNumber}.
+     *
      * @param firstSequenceNumber first sequence number
-     * @param entries the positions of the aggregate
+     * @param entries             the positions of the aggregate
      */
-    public StandardIndexEntries(long firstSequenceNumber, List<Integer> entries) {
+    public StandardIndexEntries(long firstSequenceNumber, Integer[] entries) {
         this.entries = new AppendOnlyList<>(entries);
         this.firstSequenceNumber = firstSequenceNumber;
     }
@@ -72,6 +72,11 @@ public class StandardIndexEntries implements IndexEntries {
         if (snapshot) {
             return this;
         }
+
+        if (minSequenceNumber <= firstSequenceNumber && maxSequenceNumber >= firstSequenceNumber + size()) {
+            return this;
+        }
+
         List<Integer> reducedEntries = new ArrayList<>();
         long i = firstSequenceNumber;
         for (Integer entry : entries) {
@@ -80,7 +85,8 @@ public class StandardIndexEntries implements IndexEntries {
             }
             i++;
         }
-        return new StandardIndexEntries(Math.max(minSequenceNumber, firstSequenceNumber), reducedEntries);
+        return new StandardIndexEntries(Math.max(minSequenceNumber, firstSequenceNumber),
+                                        reducedEntries.toArray(new Integer[0]));
     }
 
     /**

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntriesSerializer.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntriesSerializer.java
@@ -14,8 +14,6 @@ import org.mapdb.DataOutput2;
 import org.mapdb.Serializer;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 /**
@@ -66,9 +64,9 @@ public class StandardIndexEntriesSerializer implements Serializer<IndexEntries> 
     public IndexEntries deserialize(@Nonnull DataInput2 input, int available) throws IOException {
         int count = input.unpackInt();
         long sequenceNumber = input.unpackLong();
-        List<Integer> entries = new ArrayList<>(count);
+        Integer[] entries = new Integer[count];
         for (int i = 0; i < count; i++) {
-            entries.add(input.unpackInt());
+            entries[i] = input.unpackInt();
         }
         return new StandardIndexEntries(sequenceNumber, entries);
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntriesTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/StandardIndexEntriesTest.java
@@ -4,7 +4,6 @@ package io.axoniq.axonserver.localstorage.file;
 import org.junit.*;
 
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -23,8 +22,7 @@ public class StandardIndexEntriesTest {
 
     @Test
     public void testRangeDuringWriting() throws InterruptedException {
-        LinkedList<Integer> list = new LinkedList<>();
-        StandardIndexEntries testSubject = new StandardIndexEntries(0, list);
+        StandardIndexEntries testSubject = new StandardIndexEntries(0);
         AtomicBoolean running = new AtomicBoolean(true);
         AtomicInteger counter = new AtomicInteger(0);
         CountDownLatch started = new CountDownLatch(1);
@@ -47,7 +45,6 @@ public class StandardIndexEntriesTest {
                 assertEquals(expectedPosition, position);
                 expectedPosition = expectedPosition + 1;
             }
-            System.out.println(expectedPosition);
         }
         running.set(false);
     }
@@ -67,5 +64,12 @@ public class StandardIndexEntriesTest {
                    System.currentTimeMillis() - before < 250);
         Assert.assertEquals(1998, (int) standardIndexEntries.positions().get(1998));
         Assert.assertEquals(4000, (int) standardIndexEntries.positions().get(4000));
+    }
+
+    @Test
+    public void range() {
+        StandardIndexEntries standardIndexEntries = new StandardIndexEntries(10, new Integer[]{0, 1, 2, 3, 4, 5, 6});
+        IndexEntries subset = standardIndexEntries.range(11, 14, false);
+        assertEquals(3, subset.size());
     }
 }


### PR DESCRIPTION
Each entry in the append only list contained an ArrayList with entries. Changed to have each node contain an array, as the content is final. As there are many nodes in the append only list for the active segment (depending on the transaction size, number of events in the transaction, fill factor of the active segment), reducing the memory usage will help in the overall heap usage of Axon Server. In my testcase the memory usage for the index for the current segment dropped by almost 50%.