### PR TITLE
Load balancing operations for processors should ignore stopped instances

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/balancing/strategy/DefaultInstancesRepository.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/balancing/strategy/DefaultInstancesRepository.java
@@ -11,6 +11,7 @@ package io.axoniq.axonserver.component.processor.balancing.strategy;
 
 import io.axoniq.axonserver.component.processor.balancing.SameProcessor;
 import io.axoniq.axonserver.component.processor.balancing.TrackingEventProcessor;
+import io.axoniq.axonserver.component.processor.listener.ClientProcessor;
 import io.axoniq.axonserver.component.processor.listener.ClientProcessors;
 import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
 import io.axoniq.axonserver.grpc.control.EventProcessorInfo.SegmentStatus;
@@ -37,6 +38,7 @@ public class DefaultInstancesRepository implements ThreadNumberBalancing.Instanc
     public Iterable<ThreadNumberBalancing.Application> findFor(TrackingEventProcessor processor) {
         return () -> stream(processors.spliterator(), false)
                 .filter(new SameProcessor(processor))
+                .filter(ClientProcessor::running)
                 .map(p -> {
                     EventProcessorInfo i = p.eventProcessorInfo();
                     int threadPoolSize = i.getAvailableThreads() + i.getSegmentStatusCount();

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/listener/ClientProcessor.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/listener/ClientProcessor.java
@@ -26,7 +26,7 @@ public interface ClientProcessor extends ComponentItem, Iterable<SegmentStatus> 
 
     EventProcessorInfo eventProcessorInfo();
 
-    default Boolean running() {
+    default boolean running() {
         return eventProcessorInfo().getRunning();
     }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/EventProcessorStatusRefreshTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/EventProcessorStatusRefreshTest.java
@@ -29,11 +29,11 @@ public class EventProcessorStatusRefreshTest {
     private EventProcessorIdentifier processorA = new EventProcessorIdentifier("processorA", "");
     private EventProcessorIdentifier processorB = new EventProcessorIdentifier("processorB", "");
     private EventProcessorIdentifier processorC = new EventProcessorIdentifier("processorC", "");
-    private ClientProcessor clientProcessor1 = new FakeClientProcessor("redClient", false, "processorA");
-    private ClientProcessor clientProcessor2 = new FakeClientProcessor("redClient", false, "processorB");
-    private ClientProcessor clientProcessor3 = new FakeClientProcessor("greenClient", false, "processorB");
-    private ClientProcessor clientProcessor4 = new FakeClientProcessor("blueClient", false, "processorB");
-    private ClientProcessor clientProcessor5 = new FakeClientProcessor("blueClient", false, "processorC");
+    private ClientProcessor clientProcessor1 = new FakeClientProcessor("redClient", false, "processorA", true);
+    private ClientProcessor clientProcessor2 = new FakeClientProcessor("redClient", false, "processorB", true);
+    private ClientProcessor clientProcessor3 = new FakeClientProcessor("greenClient", false, "processorB", true);
+    private ClientProcessor clientProcessor4 = new FakeClientProcessor("blueClient", false, "processorB", true);
+    private ClientProcessor clientProcessor5 = new FakeClientProcessor("blueClient", false, "processorC", true);
     private List<ClientProcessor> clientProcessors = asList(clientProcessor1,
                                                             clientProcessor2,
                                                             clientProcessor3,

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/balancing/strategy/DefaultInstancesRepositoryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/balancing/strategy/DefaultInstancesRepositoryTest.java
@@ -1,0 +1,26 @@
+package io.axoniq.axonserver.component.processor.balancing.strategy;
+
+import io.axoniq.axonserver.component.processor.balancing.TrackingEventProcessor;
+import io.axoniq.axonserver.component.processor.listener.ClientProcessor;
+import io.axoniq.axonserver.component.processor.listener.FakeClientProcessor;
+import io.axoniq.axonserver.topology.Topology;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+public class DefaultInstancesRepositoryTest {
+
+    @Test
+    public void testRepositoryFiltersOutStoppedProcessorInstances() {
+        DefaultInstancesRepository testSubject = new DefaultInstancesRepository(() -> Arrays.<ClientProcessor>asList(new FakeClientProcessor("runningClientId", true, "processorName", true),
+                                                                                                                     new FakeClientProcessor("stoppedClientId", true, "processorName", false)).iterator());
+
+        Iterator<ThreadNumberBalancing.Application> actual = testSubject.findFor(new TrackingEventProcessor("processorName", Topology.DEFAULT_CONTEXT)).iterator();
+        assertTrue(actual.hasNext());
+        assertTrue(actual.next().toString().contains("runningClientId"));
+        assertFalse(actual.hasNext());
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/listener/FakeClientProcessor.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/listener/FakeClientProcessor.java
@@ -28,9 +28,10 @@ public class FakeClientProcessor implements ClientProcessor {
 
     private final EventProcessorInfo eventProcessorInfo;
 
-    public FakeClientProcessor(String clientId, boolean belongsToComponent, String processorName) {
+    public FakeClientProcessor(String clientId, boolean belongsToComponent, String processorName, boolean running) {
         this(clientId, belongsToComponent, EventProcessorInfo.newBuilder()
                                                              .setProcessorName(processorName)
+                                                             .setRunning(running)
                                                              .build());
     }
 


### PR DESCRIPTION
The load balancing operations for Streaming Processors did not take into account that stopped processors should not participate in the balancing.