### PR TITLE
Fix list aggregate events performance issues

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/AggregateReader.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/AggregateReader.java
@@ -105,7 +105,7 @@ public class AggregateReader {
                                    long maxSequenceNumber){
         if (useSnapshots){
             return snapshotReader.snapshot(aggregateId, minSequenceNumber, maxSequenceNumber)
-            .filter(snapshot -> snapshot.getAggregateSequenceNumber() >= maxSequenceNumber);
+            .filter(snapshot -> snapshot.getAggregateSequenceNumber() < maxSequenceNumber);
         } else {
             return Mono.empty();
         }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/DataFeatcherSchedulerProvider.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/DataFeatcherSchedulerProvider.java
@@ -1,0 +1,29 @@
+package io.axoniq.axonserver.localstorage;
+
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+/**
+ * @author Stefan Dragisic
+ * @author Sara Pellegrini
+ * @since 4.5.3
+ */
+
+public class DataFeatcherSchedulerProvider implements Supplier<ExecutorService> {
+
+    private static ExecutorService dataFetcher;
+
+    public static void setDataFetcher(ExecutorService dataFetcher) {
+        DataFeatcherSchedulerProvider.dataFetcher = dataFetcher;
+    }
+
+    @Override
+    public ExecutorService get() {
+        if (dataFetcher == null) {
+            return Executors.newFixedThreadPool(24, new CustomizableThreadFactory("data-fetcher-"));
+        } else return dataFetcher;
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/DataFetcherSchedulerProvider.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/DataFetcherSchedulerProvider.java
@@ -23,7 +23,10 @@ public class DataFetcherSchedulerProvider implements Supplier<ExecutorService> {
     @Override
     public ExecutorService get() {
         if (dataFetcher == null) {
-            return Executors.newFixedThreadPool(24, new CustomizableThreadFactory("data-fetcher-"));
-        } else return dataFetcher;
+            DataFetcherSchedulerProvider.setDataFetcher(Executors.newFixedThreadPool(24,
+                                                                                     new CustomizableThreadFactory(
+                                                                                             "data-fetcher-")));
+        }
+        return dataFetcher;
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/DataFetcherSchedulerProvider.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/DataFetcherSchedulerProvider.java
@@ -12,12 +12,12 @@ import java.util.function.Supplier;
  * @since 4.5.3
  */
 
-public class DataFeatcherSchedulerProvider implements Supplier<ExecutorService> {
+public class DataFetcherSchedulerProvider implements Supplier<ExecutorService> {
 
     private static ExecutorService dataFetcher;
 
     public static void setDataFetcher(ExecutorService dataFetcher) {
-        DataFeatcherSchedulerProvider.dataFetcher = dataFetcher;
+        DataFetcherSchedulerProvider.dataFetcher = dataFetcher;
     }
 
     @Override

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -86,7 +86,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
     private final Logger logger = LoggerFactory.getLogger(LocalEventStore.class);
     private final Map<String, Workers> workersMap = new ConcurrentHashMap<>();
     private final EventStoreFactory eventStoreFactory;
-    public final ExecutorService dataFetcher;
+    private final ExecutorService dataFetcher;
     private final ExecutorService dataWriter;
     private final MeterFactory meterFactory;
     private final StorageTransactionManagerFactory storageTransactionManagerFactory;
@@ -143,7 +143,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
         this.maxEventCount = Math.min(maxEventCount, Short.MAX_VALUE);
         this.blacklistedSendAfter = blacklistedSendAfter;
         this.dataFetcher = Executors.newFixedThreadPool(fetcherThreads, new CustomizableThreadFactory("data-fetcher-"));
-        DataFeatcherSchedulerProvider.setDataFetcher(dataFetcher);
+        DataFetcherSchedulerProvider.setDataFetcher(dataFetcher);
         this.dataWriter = Executors.newFixedThreadPool(writerThreads, new CustomizableThreadFactory("data-writer-"));
         this.eventDecorator = eventDecorator;
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/SnapshotReader.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/SnapshotReader.java
@@ -26,7 +26,7 @@ public class SnapshotReader {
     private final Supplier<ExecutorService> dataFetcherSchedulerProvider;
 
     public SnapshotReader(EventStorageEngine datafileManagerChain) {
-        this(datafileManagerChain,new DataFeatcherSchedulerProvider());
+        this(datafileManagerChain,new DataFetcherSchedulerProvider());
     }
 
     public SnapshotReader(EventStorageEngine datafileManagerChain,  Supplier<ExecutorService> dataFetcherSchedulerSupplier) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/SnapshotReader.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/SnapshotReader.java
@@ -9,8 +9,13 @@
 
 package io.axoniq.axonserver.localstorage;
 
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * @author Marc Gathier
@@ -18,14 +23,28 @@ import java.util.function.Consumer;
 public class SnapshotReader {
     private final EventStorageEngine datafileManagerChain;
 
+    private final Supplier<ExecutorService> dataFetcherSchedulerProvider;
+
     public SnapshotReader(EventStorageEngine datafileManagerChain) {
+        this(datafileManagerChain,new DataFeatcherSchedulerProvider());
+    }
+
+    public SnapshotReader(EventStorageEngine datafileManagerChain,  Supplier<ExecutorService> dataFetcherSchedulerSupplier) {
         this.datafileManagerChain = datafileManagerChain;
+        this.dataFetcherSchedulerProvider = dataFetcherSchedulerSupplier;
     }
 
     public Optional<SerializedEvent> readSnapshot(String aggregateId, long minSequenceNumber, long maxSequenceNumber) {
         return datafileManagerChain
                 .getLastEvent(aggregateId, minSequenceNumber, maxSequenceNumber)
                 .map(SerializedEvent::asSnapshot);
+    }
+
+    public Mono<SerializedEvent> snapshot(String aggregateId, long minSequenceNumber, long maxSequenceNumber) {
+        return Mono.fromCallable(()->readSnapshot(aggregateId,minSequenceNumber,maxSequenceNumber))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .subscribeOn(Schedulers.fromExecutorService(dataFetcherSchedulerProvider.get()));
     }
 
     public void streamByAggregateId(String aggregateId, long minSequenceNumber, long maxSequenceNumber, int maxResults, Consumer<SerializedEvent> eventConsumer) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/EventSourceFlux.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/EventSourceFlux.java
@@ -1,6 +1,6 @@
 package io.axoniq.axonserver.localstorage.file;
 
-import io.axoniq.axonserver.localstorage.DataFeatcherSchedulerProvider;
+import io.axoniq.axonserver.localstorage.DataFetcherSchedulerProvider;
 import io.axoniq.axonserver.localstorage.SerializedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +36,7 @@ public class EventSourceFlux implements Supplier<Flux<SerializedEvent>> {
      * @param eventSourceFactory the factory used to open a new {@link EventSource} to access the segment file.
      */
     public EventSourceFlux(IndexEntries indexEntries, EventSourceFactory eventSourceFactory, long segment) {
-        this(indexEntries, eventSourceFactory, segment, new DataFeatcherSchedulerProvider());
+        this(indexEntries, eventSourceFactory, segment, new DataFetcherSchedulerProvider());
     }
 
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/SegmentBasedEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/SegmentBasedEventStore.java
@@ -119,7 +119,7 @@ public abstract class SegmentBasedEventStore implements EventStorageEngine {
                    .flatMapSequential(e -> eventsForPositions(e.getKey(), e.getValue()),
                            PREFETCH_SEGMENT_FILES,
                            storageProperties.getEventsPerSegmentPrefetch())
-                   .skipUntil(se -> se.getAggregateSequenceNumber() >= firstSequence)
+                   .skipUntil(se -> se.getAggregateSequenceNumber() >= firstSequence) //todo for safe guard, remove in 4.6
                    .takeWhile(se -> se.getAggregateSequenceNumber() < lastSequence)
                    .name("event_stream")
                    .tag("context", context)

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StorageProperties.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StorageProperties.java
@@ -104,7 +104,7 @@ public class StorageProperties implements Cloneable {
     /**
      * Define how many events to prefetch from disk when streaming events to the client
      */
-    private int eventsPerSegmentPrefetch = 50;
+    private int eventsPerSegmentPrefetch = 10;
 
     /**
      * Size of the buffer when reading from non-memory mapped files. Defaults to 32kiB.


### PR DESCRIPTION
Fixes issues: 
- parallel segment reading
- initial sequence number always starts from zero
- events prefetching 
- reading events on gRPC threads
- reading snapshots on gRPC threads