### PR TITLE
Option to propagate exceptions from Spring event listeners

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
@@ -16,7 +16,7 @@ import io.axoniq.axonserver.access.user.UserControllerFacade;
 import io.axoniq.axonserver.applicationevents.UserEvents;
 import io.axoniq.axonserver.exception.ErrorCode;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
-import io.axoniq.axonserver.exception.PropagatingEventException;
+import io.axoniq.axonserver.exception.CriticalEventException;
 import io.axoniq.axonserver.grpc.AxonServerClientService;
 import io.axoniq.axonserver.grpc.DefaultInstructionAckSource;
 import io.axoniq.axonserver.grpc.InstructionAckSource;
@@ -271,7 +271,7 @@ public class AxonServerStandardConfiguration {
             protected void invokeListener(ApplicationListener<?> listener, ApplicationEvent event) {
                 try {
                     super.invokeListener(listener, event);
-                } catch (PropagatingEventException ex) {
+                } catch (CriticalEventException ex) {
                     throw ex;
                 } catch (RuntimeException ex) {
                     logger.warn("Invoking listener {} failed", listener, ex);

--- a/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
@@ -16,6 +16,7 @@ import io.axoniq.axonserver.access.user.UserControllerFacade;
 import io.axoniq.axonserver.applicationevents.UserEvents;
 import io.axoniq.axonserver.exception.ErrorCode;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
+import io.axoniq.axonserver.exception.PropagatingEventException;
 import io.axoniq.axonserver.grpc.AxonServerClientService;
 import io.axoniq.axonserver.grpc.DefaultInstructionAckSource;
 import io.axoniq.axonserver.grpc.InstructionAckSource;
@@ -270,6 +271,8 @@ public class AxonServerStandardConfiguration {
             protected void invokeListener(ApplicationListener<?> listener, ApplicationEvent event) {
                 try {
                     super.invokeListener(listener, event);
+                } catch (PropagatingEventException ex) {
+                    throw ex;
                 } catch (RuntimeException ex) {
                     logger.warn("Invoking listener {} failed", listener, ex);
                 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/exception/CriticalEventException.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/exception/CriticalEventException.java
@@ -10,12 +10,18 @@
 package io.axoniq.axonserver.exception;
 
 /**
+ * Exception to be thrown when there is a critical error while handling an application event.
+ *
  * @author Marc Gathier
  * @since 4.4.13
  */
-public class PropagatingEventException extends RuntimeException {
+public class CriticalEventException extends RuntimeException {
 
-    public PropagatingEventException(String message, Throwable cause) {
+    /**
+     * @param message describes the exception
+     * @param cause a wrapped cause
+     */
+    public CriticalEventException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/exception/PropagatingEventException.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/exception/PropagatingEventException.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2017-2021 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ *  under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.exception;
+
+/**
+ * @author Marc Gathier
+ * @since 4.4.13
+ */
+public class PropagatingEventException extends RuntimeException {
+
+    public PropagatingEventException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
if an exception is of type PropagatingEventException it is not logged by the ApplicationEventMulticaster but propagated to the caller.