### PR TITLE
Refactoring of EventStore.listAggregateSnapshots:

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -466,8 +466,28 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
         return Long.MAX_VALUE;
     }
 
-
     @Override
+    public Flux<SerializedEvent> aggregateSnapshots(String context, Authentication authentication,
+                                                    GetAggregateSnapshotsRequest request) {
+        return Flux.create(
+                sink -> listAggregateSnapshots(context, authentication, request, new StreamObserver<SerializedEvent>() {
+                    @Override
+                    public void onNext(SerializedEvent serializedEvent) {
+                        sink.next(serializedEvent);
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        sink.error(throwable);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        sink.complete();
+                    }
+                }));
+    }
+
     public void listAggregateSnapshots(String context,
                                        Authentication authentication,
                                        GetAggregateSnapshotsRequest request,

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
@@ -80,27 +80,9 @@ public interface EventStore {
      * @param request        the request containing the aggregate identifier and read options
      * @return a {@link Flux} of all {@link SerializedEvent}s for an aggregate according whit the specified request.
      */
-    default Flux<SerializedEvent> aggregateSnapshots(String context,
-                                                     Authentication authentication,
-                                                     GetAggregateSnapshotsRequest request) {
-        return Flux.create(
-                sink -> listAggregateSnapshots(context, authentication, request, new StreamObserver<SerializedEvent>() {
-                    @Override
-                    public void onNext(SerializedEvent serializedEvent) {
-                        sink.next(serializedEvent);
-                    }
-
-                    @Override
-                    public void onError(Throwable throwable) {
-                        sink.error(throwable);
-                    }
-
-                    @Override
-                    public void onCompleted() {
-                        sink.complete();
-                    }
-                }));
-    }
+    Flux<SerializedEvent> aggregateSnapshots(String context,
+                                             Authentication authentication,
+                                             GetAggregateSnapshotsRequest request);
 
     /**
      * Retrieves the Events from a given tracking token. Results are streamed rather than returned at once. Caller gets
@@ -125,9 +107,6 @@ public interface EventStore {
 
     StreamObserver<QueryEventsRequest> queryEvents(String context, Authentication authentication,
                                                    StreamObserver<QueryEventsResponse> responseObserver);
-
-    void listAggregateSnapshots(String context, Authentication authentication, GetAggregateSnapshotsRequest request,
-                                StreamObserver<SerializedEvent> responseObserver);
 
     /**
      * Deletes all event data in a given context (Only intended for development environments).

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStoreTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStoreTest.java
@@ -197,14 +197,13 @@ public class LocalEventStoreTest {
     }
 
     @Test
-    public void listAggregateSnapshots() throws InterruptedException {
-        FakeStreamObserver<SerializedEvent> events = new FakeStreamObserver<>();
-        testSubject.listAggregateSnapshots("demo", null,
-                                           GetAggregateSnapshotsRequest.newBuilder()
-                                                                       .build(),
-                                           events);
+    public void aggregateSnapshots() {
+        StepVerifier.create(testSubject.aggregateSnapshots("demo",
+                                       null,
+                                       GetAggregateSnapshotsRequest.getDefaultInstance()))
+                    .expectNextCount(4)
+                    .verifyComplete();
 
-        assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(1, events.completedCount()));
         assertEquals(4, eventInterceptors.readSnapshot);
         assertEquals(0, eventInterceptors.readEvent);
     }


### PR DESCRIPTION
 - removed StreamObservers
 - usage of project reactor types
   - the actual implementation only wraps previous approach