### PR TITLE
Refactoring of EventStore.getFirstToken

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -19,7 +19,6 @@ import io.axoniq.axonserver.grpc.event.EventWithToken;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
 import io.axoniq.axonserver.grpc.event.GetAggregateSnapshotsRequest;
 import io.axoniq.axonserver.grpc.event.GetEventsRequest;
-import io.axoniq.axonserver.grpc.event.GetFirstTokenRequest;
 import io.axoniq.axonserver.grpc.event.GetLastTokenRequest;
 import io.axoniq.axonserver.grpc.event.GetTokenAtRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
@@ -31,7 +30,6 @@ import io.axoniq.axonserver.interceptor.DefaultExecutionContext;
 import io.axoniq.axonserver.interceptor.EventInterceptors;
 import io.axoniq.axonserver.localstorage.query.QueryEventsRequestStreamObserver;
 import io.axoniq.axonserver.localstorage.transaction.StorageTransactionManagerFactory;
-import io.axoniq.axonserver.message.event.EventStore;
 import io.axoniq.axonserver.metric.BaseMetricName;
 import io.axoniq.axonserver.metric.DefaultMetricCollector;
 import io.axoniq.axonserver.metric.MeterFactory;
@@ -610,11 +608,8 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
     }
 
     @Override
-    public void getFirstToken(String context, GetFirstTokenRequest request,
-                              StreamObserver<TrackingToken> responseObserver) {
-        long token = workers(context).eventStreamReader.getFirstToken();
-        responseObserver.onNext(TrackingToken.newBuilder().setToken(token).build());
-        responseObserver.onCompleted();
+    public Mono<Long> firstEventToken(String context) {
+        return Mono.just(workers(context).eventStreamReader.getFirstToken());
     }
 
     @Override

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -432,13 +432,12 @@ public class EventDispatcher implements AxonServerClientService {
         ForwardingStreamObserver<TrackingToken> responseObserver = new ForwardingStreamObserver<>(logger,
                 "getFirstToken",
                 callStreamObserver);
-        checkConnection(contextProvider.getContext(), responseObserver).ifPresent(client ->
-                client.getFirstToken(
-                        contextProvider
-                                .getContext(),
-                        request,
-                        responseObserver)
-        );
+        checkConnection(contextProvider.getContext(), responseObserver)
+                .ifPresent(client -> client.firstEventToken(contextProvider.getContext())
+                                           .map(token -> TrackingToken.newBuilder().setToken(token).build())
+                                           .subscribe(responseObserver::onNext,
+                                                      responseObserver::onError,
+                                                      responseObserver::onCompleted));
     }
 
     private Optional<EventStore> checkConnection(String context, StreamObserver<?> responseObserver) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
@@ -13,7 +13,6 @@ import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
 import io.axoniq.axonserver.grpc.event.GetAggregateSnapshotsRequest;
 import io.axoniq.axonserver.grpc.event.GetEventsRequest;
-import io.axoniq.axonserver.grpc.event.GetFirstTokenRequest;
 import io.axoniq.axonserver.grpc.event.GetLastTokenRequest;
 import io.axoniq.axonserver.grpc.event.GetTokenAtRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
@@ -96,7 +95,13 @@ public interface EventStore {
                                           Authentication authentication,
                                           Flux<GetEventsRequest> requestFlux);
 
-    void getFirstToken(String context, GetFirstTokenRequest request, StreamObserver<TrackingToken> responseObserver);
+    /**
+     * Gets the token of first event in event store.
+     *
+     * @param context the context in which the token will be searched for
+     * @return a mono of the token
+     */
+    Mono<Long> firstEventToken(String context);
 
     void getLastToken(String context, GetLastTokenRequest request, StreamObserver<TrackingToken> responseObserver);
 


### PR DESCRIPTION
 - removed StreamObservers
 - usage of project reactor types
   - the actual implementation only wraps previous approach