### PR TITLE
Refactoring of EventStore.getTokenAt

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -56,6 +56,7 @@ import reactor.core.scheduler.Schedulers;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -624,6 +625,29 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
     }
 
     @Override
+    public Mono<Long> eventTokenAt(String context, Instant timestamp) {
+        return Mono.create(sink -> sink.onRequest(requested -> {
+            getTokenAt(context,
+                       GetTokenAtRequest.newBuilder().setInstant(timestamp.toEpochMilli()).build(),
+                       new StreamObserver<TrackingToken>() {
+                           @Override
+                           public void onNext(TrackingToken trackingToken) {
+                               sink.success(trackingToken.getToken());
+                           }
+
+                           @Override
+                           public void onError(Throwable throwable) {
+                               sink.error(throwable);
+                           }
+
+                           @Override
+                           public void onCompleted() {
+                               //nothing to do, already completed
+                           }
+                       });
+        }));
+    }
+
     public void getTokenAt(String context, GetTokenAtRequest request, StreamObserver<TrackingToken> responseObserver) {
         runInDataFetcherPool(() -> {
             long token = workers(context).eventStreamReader.getTokenAt(request.getInstant());

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -57,6 +57,7 @@ import reactor.util.retry.RetryBackoffSpec;
 
 import java.io.InputStream;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -442,8 +443,12 @@ public class EventDispatcher implements AxonServerClientService {
                 "getTokenAt",
                 callStreamObserver);
         checkConnection(contextProvider.getContext(), responseObserver)
-                .ifPresent(client -> client.getTokenAt(contextProvider.getContext(), request, responseObserver)
-                );
+                .ifPresent(client -> client.eventTokenAt(contextProvider.getContext(),
+                                                         Instant.ofEpochMilli(request.getInstant()))
+                                           .map(token -> TrackingToken.newBuilder().setToken(token).build())
+                                           .subscribe(responseObserver::onNext,
+                                                      responseObserver::onError,
+                                                      responseObserver::onCompleted));
     }
 
     public void readHighestSequenceNr(ReadHighestSequenceNrRequest request,

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
@@ -13,19 +13,18 @@ import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
 import io.axoniq.axonserver.grpc.event.GetAggregateSnapshotsRequest;
 import io.axoniq.axonserver.grpc.event.GetEventsRequest;
-import io.axoniq.axonserver.grpc.event.GetLastTokenRequest;
-import io.axoniq.axonserver.grpc.event.GetTokenAtRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
 import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrRequest;
 import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrResponse;
-import io.axoniq.axonserver.grpc.event.TrackingToken;
 import io.axoniq.axonserver.localstorage.SerializedEvent;
 import io.axoniq.axonserver.localstorage.SerializedEventWithToken;
 import io.grpc.stub.StreamObserver;
 import org.springframework.security.core.Authentication;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.time.Instant;
 
 /**
  * Provides a facade to the event store.
@@ -111,7 +110,14 @@ public interface EventStore {
      */
     Mono<Long> lastEventToken(String context);
 
-    void getTokenAt(String context, GetTokenAtRequest request, StreamObserver<TrackingToken> responseObserver);
+    /**
+     * Gets the token of the event at specific position in time.
+     *
+     * @param context   the context in which the token will be searched for
+     * @param timestamp the timestamp to search the tracking token
+     * @return a mono of the token
+     */
+    Mono<Long> eventTokenAt(String context, Instant timestamp);
 
     void readHighestSequenceNr(String context, ReadHighestSequenceNrRequest request,
                                StreamObserver<ReadHighestSequenceNrResponse> responseObserver);


### PR DESCRIPTION
 - removed StreamObservers
 - usage of project reactor types
   - the actual implementation only wraps previous approach