### PR TITLE
Refactoring of EventStore.queryEvents:

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -194,13 +194,19 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
      * @param context the context to be cleared
      */
     @Override
-    public void deleteAllEventData(String context) {
-        Workers workers = workersMap.remove(context);
-        if (workers == null) {
-            return;
-        }
-        workers.close(true);
-        initContext(context, false);
+    public Mono<Void> deleteAllEventData(String context) {
+        return Mono.create(sink -> {
+            try {
+                Workers workers = workersMap.remove(context);
+                if (workers != null) {
+                    workers.close(true);
+                    initContext(context, false);
+                }
+                sink.success();
+            } catch (Exception e) {
+                sink.error(e);
+            }
+        });
     }
 
     public void cancel(String context) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -284,7 +284,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
 
     @Override
     public Mono<Void> appendEvents(String context, Flux<Event> events, Authentication authentication) {
-        return Mono.create(sink -> sink.onRequest(l -> {
+        return Mono.create(sink -> {
             StreamObserver<InputStream> inputStream =
                     createAppendEventConnection(context, authentication, new StreamObserver<Confirmation>() {
                         @Override
@@ -305,7 +305,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
             events.doOnComplete(inputStream::onCompleted)
                   .doOnError(inputStream::onError)
                   .subscribe(event -> inputStream.onNext(new ByteArrayInputStream(event.toByteArray())));
-        }));
+        });
     }
 
     public StreamObserver<InputStream> createAppendEventConnection(String context,
@@ -517,7 +517,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
     @Override
     public Flux<SerializedEventWithToken> events(String context, Authentication authentication,
                                                  Flux<GetEventsRequest> requestFlux) {
-        return Flux.create(sink -> sink.onRequest(requested -> {
+        return Flux.create(sink -> {
             StreamObserver<GetEventsRequest> requestStreamObserver =
                     listEvents(context,
                                authentication,
@@ -546,7 +546,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
             requestFlux.subscribe(requestStreamObserver::onNext,
                                   requestStreamObserver::onError,
                                   requestStreamObserver::onCompleted);
-        }));
+        });
     }
 
     public StreamObserver<GetEventsRequest> listEvents(String context, Authentication authentication,
@@ -628,7 +628,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
 
     @Override
     public Mono<Long> eventTokenAt(String context, Instant timestamp) {
-        return Mono.create(sink -> sink.onRequest(requested -> {
+        return Mono.create(sink ->
             getTokenAt(context,
                        GetTokenAtRequest.newBuilder().setInstant(timestamp.toEpochMilli()).build(),
                        new StreamObserver<TrackingToken>() {
@@ -646,8 +646,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
                            public void onCompleted() {
                                //nothing to do, already completed
                            }
-                       });
-        }));
+                       }));
     }
 
     public void getTokenAt(String context, GetTokenAtRequest request, StreamObserver<TrackingToken> responseObserver) {
@@ -660,7 +659,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
 
     @Override
     public Mono<Long> highestSequenceNumber(String context, String aggregateId) {
-        return Mono.create(sink -> sink.onRequest(requested -> {
+        return Mono.create(sink ->
             readHighestSequenceNr(context,
                                   ReadHighestSequenceNrRequest.newBuilder().setAggregateId(aggregateId).build(),
                                   new StreamObserver<ReadHighestSequenceNrResponse>() {
@@ -678,8 +677,7 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
                                       public void onCompleted() {
                                           //nothing to do, already completed
                                       }
-                                  });
-        }));
+                                  }));
     }
 
     public void readHighestSequenceNr(String context, ReadHighestSequenceNrRequest request,
@@ -703,6 +701,32 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
     }
 
     @Override
+    public Flux<QueryEventsResponse> queryEvents(String context, Flux<QueryEventsRequest> query,
+                                                 Authentication authentication) {
+        return Flux.create(sink -> {
+            StreamObserver<QueryEventsRequest> requestStream =
+                    queryEvents(context,
+                                authentication,
+                                new StreamObserver<QueryEventsResponse>() {
+                                    @Override
+                                    public void onNext(QueryEventsResponse queryEventsResponse) {
+                                        sink.next(queryEventsResponse);
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable throwable) {
+                                        sink.error(throwable);
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        sink.complete();
+                                    }
+                                });
+            query.subscribe(requestStream::onNext, requestStream::onError, requestStream::onCompleted);
+        });
+    }
+
     public StreamObserver<QueryEventsRequest> queryEvents(String context, Authentication authentication,
                                                           StreamObserver<QueryEventsResponse> responseObserver) {
         Workers workers = workers(context);

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
@@ -128,8 +128,16 @@ public interface EventStore {
      */
     Mono<Long> highestSequenceNumber(String context, String aggregateId);
 
-    StreamObserver<QueryEventsRequest> queryEvents(String context, Authentication authentication,
-                                                   StreamObserver<QueryEventsResponse> responseObserver);
+    /**
+     * Queries this event store based on the provided {@code query}.
+     *
+     * @param context        the context in which to query
+     * @param query          the flux of queries
+     * @param authentication the authentication
+     * @return a flux of results of the query
+     */
+    Flux<QueryEventsResponse> queryEvents(String context, Flux<QueryEventsRequest> query,
+                                          Authentication authentication);
 
     /**
      * Deletes all event data in a given context (Only intended for development environments).

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
@@ -15,11 +15,8 @@ import io.axoniq.axonserver.grpc.event.GetAggregateSnapshotsRequest;
 import io.axoniq.axonserver.grpc.event.GetEventsRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrRequest;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrResponse;
 import io.axoniq.axonserver.localstorage.SerializedEvent;
 import io.axoniq.axonserver.localstorage.SerializedEventWithToken;
-import io.grpc.stub.StreamObserver;
 import org.springframework.security.core.Authentication;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -143,6 +140,7 @@ public interface EventStore {
      * Deletes all event data in a given context (Only intended for development environments).
      *
      * @param context the context to be deleted
+     * @return a Mono indicating when deletion is done
      */
-    void deleteAllEventData(String context);
+    Mono<Void> deleteAllEventData(String context);
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/DevelopmentRestController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/DevelopmentRestController.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 import java.security.Principal;
 
@@ -36,9 +37,9 @@ public class DevelopmentRestController {
      */
     @DeleteMapping("purge-events")
     @ApiOperation(value="Clears all event and snapshot data from Axon Server", notes = "Only for development/test environments.")
-    public void resetEventStore(Principal principal) {
+    public Mono<Void> resetEventStore(Principal principal) {
         auditLog.warn("[{}] Request to delete all events in context \"default\".", AuditLog.username(principal));
 
-        eventStoreLocator.getEventStore("default").deleteAllEventData("default");
+        return eventStoreLocator.getEventStore("default").deleteAllEventData("default");
     }
 }

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStorageEngineTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/LocalEventStorageEngineTest.java
@@ -18,8 +18,6 @@ import io.axoniq.axonserver.localstorage.transaction.StorageTransactionManager;
 import io.axoniq.axonserver.localstorage.transaction.StorageTransactionManagerFactory;
 import io.axoniq.axonserver.metric.DefaultMetricCollector;
 import io.axoniq.axonserver.metric.MeterFactory;
-import io.axoniq.axonserver.test.FakeStreamObserver;
-import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.*;
 import reactor.core.publisher.Flux;

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
@@ -187,28 +187,8 @@ public class EventDispatcherTest {
     public void queryEvents() {
         FakeStreamObserver<QueryEventsResponse> responseObserver = new FakeStreamObserver<>();
         AtomicReference<StreamObserver<QueryEventsResponse>> eventStoreOutputStreamRef = new AtomicReference<>();
-        StreamObserver<QueryEventsRequest> eventStoreResponseStream = new StreamObserver<QueryEventsRequest>() {
-            @Override
-            public void onNext(QueryEventsRequest value) {
-                StreamObserver<QueryEventsResponse> responseStream = eventStoreOutputStreamRef.get();
-                responseStream.onNext(QueryEventsResponse.newBuilder().build());
-                responseStream.onCompleted();
-            }
-
-            @Override
-            public void onError(Throwable t) {
-
-            }
-
-            @Override
-            public void onCompleted() {
-
-            }
-        };
-        when(eventStoreClient.queryEvents(any(), any(), any(StreamObserver.class))).then(a -> {
-            eventStoreOutputStreamRef.set((StreamObserver<QueryEventsResponse>) a.getArguments()[2]);
-            return eventStoreResponseStream;
-        });
+        when(eventStoreClient.queryEvents(any(), any(Flux.class), any()))
+                .thenReturn(Flux.just(QueryEventsResponse.getDefaultInstance()));
         StreamObserver<QueryEventsRequest> inputStream = testSubject.queryEvents(responseObserver);
         inputStream.onNext(QueryEventsRequest.newBuilder().build());
         verify(eventStoreLocator).getEventStore(Topology.DEFAULT_CONTEXT, false);


### PR DESCRIPTION
 - removed StreamObservers
 - usage of project reactor types
   - the actual implementation only wraps previous approach
 - removed unnecessary indirection `sink -> sink.onRequest`