### PR TITLE
Refactoring of EventStore.deleteAllEventData:

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -194,13 +194,19 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
      * @param context the context to be cleared
      */
     @Override
-    public void deleteAllEventData(String context) {
-        Workers workers = workersMap.remove(context);
-        if (workers == null) {
-            return;
-        }
-        workers.close(true);
-        initContext(context, false);
+    public Mono<Void> deleteAllEventData(String context) {
+        return Mono.create(sink -> {
+            try {
+                Workers workers = workersMap.remove(context);
+                if (workers != null) {
+                    workers.close(true);
+                    initContext(context, false);
+                }
+                sink.success();
+            } catch (Exception e) {
+                sink.error(e);
+            }
+        });
     }
 
     public void cancel(String context) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventStore.java
@@ -15,11 +15,8 @@ import io.axoniq.axonserver.grpc.event.GetAggregateSnapshotsRequest;
 import io.axoniq.axonserver.grpc.event.GetEventsRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
 import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrRequest;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrResponse;
 import io.axoniq.axonserver.localstorage.SerializedEvent;
 import io.axoniq.axonserver.localstorage.SerializedEventWithToken;
-import io.grpc.stub.StreamObserver;
 import org.springframework.security.core.Authentication;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -143,6 +140,7 @@ public interface EventStore {
      * Deletes all event data in a given context (Only intended for development environments).
      *
      * @param context the context to be deleted
+     * @return a Mono indicating when deletion is done
      */
-    void deleteAllEventData(String context);
+    Mono<Void> deleteAllEventData(String context);
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/DevelopmentRestController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/DevelopmentRestController.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 import java.security.Principal;
 
@@ -36,9 +37,9 @@ public class DevelopmentRestController {
      */
     @DeleteMapping("purge-events")
     @ApiOperation(value="Clears all event and snapshot data from Axon Server", notes = "Only for development/test environments.")
-    public void resetEventStore(Principal principal) {
+    public Mono<Void> resetEventStore(Principal principal) {
         auditLog.warn("[{}] Request to delete all events in context \"default\".", AuditLog.username(principal));
 
-        eventStoreLocator.getEventStore("default").deleteAllEventData("default");
+        return eventStoreLocator.getEventStore("default").deleteAllEventData("default");
     }
 }


### PR DESCRIPTION
 - removed StreamObservers
 - usage of project reactor types
   - the actual implementation only wraps previous approach