### PR TITLE
Skip to start and stop AS instance for integration tests when ntegration tests are not performed.

### DIFF
--- a/axonserver/pom.xml
+++ b/axonserver/pom.xml
@@ -380,6 +380,7 @@
                             <goal>start</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.integration.tests}</skip>
                             <wait>5000</wait>
                             <workingDirectory>target/integration</workingDirectory>
                         </configuration>
@@ -389,6 +390,9 @@
                         <goals>
                             <goal>stop</goal>
                         </goals>
+                        <configuration>
+                            <skip>${skip.integration.tests}</skip>
+                        </configuration>
                     </execution>
                     <execution>
                         <goals>


### PR DESCRIPTION
Skip start and stop AS instance for integration tests when integration tests are not performed (skip.integration.test=true)