### PR TITLE
EventDispatcher refactoring of append snapshot method

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -128,18 +128,15 @@ public class EventDispatcher {
                            context,
                            snapshot.getAggregateIdentifier());
         }
-        EventStore eventStore = eventStoreLocator.getEventStore(context);
-        if (eventStore == null) {
-            return Mono.error(new MessagingPlatformException(NO_EVENTSTORE,
-                                                             NO_EVENT_STORE_CONFIGURED + context));
-        }
-        return eventStore.appendSnapshot(context, snapshot, authentication)
-                         .doOnSuccess(v -> eventsCounter(context,
-                                                         snapshotCounter,
-                                                         BaseMetricName.AXON_SNAPSHOTS).mark())
-                         .doOnError(t -> logger.warn(ERROR_ON_CONNECTION_FROM_EVENT_STORE,
-                                                     "appendSnapshot",
-                                                     t.getMessage()));
+        return eventStoreLocator.eventStore(context)
+                                .flatMap(eventStore -> eventStore.appendSnapshot(context, snapshot, authentication)
+                                                                 .doOnSuccess(v -> eventsCounter(context,
+                                                                                                 snapshotCounter,
+                                                                                                 BaseMetricName.AXON_SNAPSHOTS).mark())
+                                                                 .doOnError(t -> logger.warn(
+                                                                         ERROR_ON_CONNECTION_FROM_EVENT_STORE,
+                                                                         "appendSnapshot",
+                                                                         t.getMessage())));
     }
 
     public Flux<SerializedEvent> aggregateEvents(String context,

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
+import reactor.test.StepVerifier;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -106,11 +107,10 @@ public class EventDispatcherTest {
 
     @Test
     public void appendSnapshot() {
-        FakeStreamObserver<Confirmation> responseObserver = new FakeStreamObserver<>();
         when(eventStoreClient.appendSnapshot(any(), any(Event.class), any())).thenReturn(Mono.empty());
-        testSubject.appendSnapshot(DEFAULT_CONTEXT, DEFAULT_PRINCIPAL, Event.newBuilder().build(), responseObserver);
+        StepVerifier.create(testSubject.appendSnapshot(DEFAULT_CONTEXT, Event.getDefaultInstance(), DEFAULT_PRINCIPAL))
+                    .verifyComplete();
         verify(eventStoreClient).appendSnapshot(any(), any(Event.class), any());
-        assertEquals(1, responseObserver.values().size());
     }
 
     @Test


### PR DESCRIPTION
`EventDispatcher.appendSnapshot` now works with reactive types i.o. `StreamObserver`s.