### PR TITLE
handle iterating over a closed event iterator

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
@@ -242,6 +242,8 @@ public class TrackingEventProcessorManager {
                     }
                     count++;
                 }
+            } catch (IllegalStateException ex) {
+                // closed during iterating events
             } catch (Exception ex) {
                 running = false;
                 sendError(ex);

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/EventByteBufferIterator.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/EventByteBufferIterator.java
@@ -93,7 +93,7 @@ public class EventByteBufferIterator extends EventIterator {
     }
 
     @Override
-    public void close() {
+    protected void doClose() {
         eventSource.close();
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/InputStreamEventIterator.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/InputStreamEventIterator.java
@@ -94,7 +94,7 @@ public class InputStreamEventIterator extends EventIterator {
     }
 
     @Override
-    public void close() {
+    protected void doClose() {
         eventSource.close();
     }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/InputStreamEventIteratorTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/InputStreamEventIteratorTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2017-2021 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ *  under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
+package io.axoniq.axonserver.localstorage.file;
+
+import io.axoniq.axonserver.localstorage.transformation.DefaultEventTransformerFactory;
+import io.axoniq.axonserver.test.TestUtils;
+import org.junit.*;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Marc Gathier
+ * @since 4.5.7
+ */
+public class InputStreamEventIteratorTest {
+    private InputStreamEventIterator testSubject;
+
+    @Before
+    public void setUp() throws Exception {
+
+        File file = new File(TestUtils
+                .fixPathOnWindows(InputStreamEventStore.class
+                                          .getResource(
+                                                  "/data/default/00000000000000000000.events")
+                                          .getFile()));
+        InputStreamEventSource eventSource = new InputStreamEventSource(file, new DefaultEventTransformerFactory());
+        testSubject = new InputStreamEventIterator(eventSource, 0, 0);
+    }
+
+    @Test
+    public void iterateClosedFile() {
+        testSubject.close();
+        try {
+            testSubject.hasNext();
+            fail("Reading from closed iterator must fail");
+        } catch (IllegalStateException expected) {
+            // expected illegal state exception
+        }
+    }
+}


### PR DESCRIPTION
when an iterator is closed, hasNext() returns an IllegalStateException