### PR TITLE
let the login page submit the form to a relative target instead of an absolute URL

### DIFF
--- a/axonserver/src/main/resources/templates/login.html
+++ b/axonserver/src/main/resources/templates/login.html
@@ -50,7 +50,7 @@
 
     <div th:if="${logout}" class="msg warning" th:text="${logout}"/>
 
-    <form th:action="@{/login}" method="post">
+    <form action="login" method="post">
         <div class="column configuration">
             <section class="login">
                 <ul>


### PR DESCRIPTION
If Axon Server is called from behind a reverse proxy the URL from the reverse proxy must be used, not the context path of axon server itself.