### PR TITLE
Added configuration option for connection

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/config/MessagingPlatformConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/MessagingPlatformConfiguration.java
@@ -107,6 +107,13 @@ public class MessagingPlatformConfiguration {
     private int metricsSynchronizationRate;
 
     /**
+     * Whether to force applications to connect to Primary nodes or Messaging Only nodes.
+     * When false, all nodes for a context are eligible to accept client connections.
+     * <p>
+     * Defaults to false.
+     */
+    private boolean forceConnectionToPrimaryOrMessagingNode = false;
+    /**
      * Expiry interval (minutes) of metrics
      */
     private int metricsInterval = 15;
@@ -364,6 +371,14 @@ public class MessagingPlatformConfiguration {
 
     public void setMetricsInterval(int metricsInterval) {
         this.metricsInterval = metricsInterval;
+    }
+
+    public boolean isForceConnectionToPrimaryOrMessagingNode() {
+        return forceConnectionToPrimaryOrMessagingNode;
+    }
+
+    public void setForceConnectionToPrimaryOrMessagingNode(boolean forceConnectionToPrimaryOrMessagingNode) {
+        this.forceConnectionToPrimaryOrMessagingNode = forceConnectionToPrimaryOrMessagingNode;
     }
 
     public long getKeepAliveTimeout() {


### PR DESCRIPTION
This option allows users to force connections to Primary or Messaging Only nodes, which is the legacy behavior. New behavior will is introduced in Axon Server Enterprise which allows all nodes in a context to accept client connections.