### PR TITLE
New endpoint /v1/backup/eventstore

### DIFF
--- a/axonserver/README.txt
+++ b/axonserver/README.txt
@@ -3,6 +3,11 @@ This is the Axon Server Standard Edition, version 4.5
 For information about the Axon Framework and Axon Server,
 visit https://docs.axoniq.io.
 
+Release Notes for version 4.5.12
+--------------------------------
+* Deprecated "/v1/backup/filenames" endpoint, use new endpoint /v1/backup/eventstore instead. The new endpoint returns all files
+  to back up, given a last closed segment number, and it also returns the currently last closed segment.
+
 Release Notes for version 4.5.11
 --------------------------------
 * Updated Spring Boot version to 2.5.12 to fix CVE-2022-22965

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventStorageEngine.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
  */
 public interface EventStorageEngine {
 
+
     enum SearchHint {
         RECENT_ONLY
     }
@@ -44,6 +45,10 @@ public interface EventStorageEngine {
     default void init(boolean validate) {
         init(validate, 0L);
     }
+
+    default long getFirstCompletedSegment() {
+        return -1;
+    };
 
     /**
      * Stores a number of events.
@@ -179,9 +184,10 @@ public interface EventStorageEngine {
     /**
      * Gets filenames to back up for this storage engine. Only relevant for file based storage.
      * @param lastSegmentBackedUp last segment backed up before
+     * @param includeActive
      * @return stream of filenames
      */
-    default Stream<String> getBackupFilenames(long lastSegmentBackedUp) {
+    default Stream<String> getBackupFilenames(long lastSegmentBackedUp, boolean includeActive) {
         throw new UnsupportedOperationException();
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -706,14 +706,15 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
         return workers(context).snapshotWriteStorage.waitingTransactions();
     }
 
-    public Stream<String> getBackupFilenames(String context, EventType eventType, long lastSegmentBackedUp) {
+    public Stream<String> getBackupFilenames(String context, EventType eventType, long lastSegmentBackedUp,
+                                             boolean includeActive) {
         try {
             Workers workers = workers(context);
             if (eventType == EventType.SNAPSHOT) {
-                return workers.snapshotStorageEngine.getBackupFilenames(lastSegmentBackedUp);
+                return workers.snapshotStorageEngine.getBackupFilenames(lastSegmentBackedUp, includeActive);
             }
 
-            return workers.eventStorageEngine.getBackupFilenames(lastSegmentBackedUp);
+            return workers.eventStorageEngine.getBackupFilenames(lastSegmentBackedUp, includeActive);
         } catch (Exception ex) {
             logger.warn("Failed to get backup filenames", ex);
         }
@@ -735,6 +736,13 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
 
     public boolean activeContext(String context) {
         return workersMap.containsKey(context) && workersMap.get(context).initialized;
+    }
+
+    public long getFirstCompletedSegment(String context, EventType type) {
+        if( EventType.EVENT.equals(type)) {
+            return workers(context).eventStorageEngine.getFirstCompletedSegment();
+        }
+        return workers(context).snapshotStorageEngine.getFirstCompletedSegment();
     }
 
     private class Workers {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/FileUtils.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/FileUtils.java
@@ -64,4 +64,15 @@ public class FileUtils {
     public static void rename(File target, File currentLocation) throws IOException {
         Files.move(target.toPath(), currentLocation.toPath(), StandardCopyOption.REPLACE_EXISTING);
     }
+
+    public static String name(File file) {
+        try {
+            return file
+                    .getCanonicalFile()
+                    .getAbsolutePath();
+        } catch (IOException e) {
+            return file.getAbsolutePath();
+        }
+    }
+
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
@@ -49,6 +49,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.axoniq.axonserver.localstorage.file.FileUtils.name;
+
 /**
  * Manages the writable segments of the event store. Once the segment is completed this class hands the segment over
  * to the next segment based event store.
@@ -287,11 +289,24 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
     }
 
     @Override
-    public Stream<String> getBackupFilenames(long lastSegmentBackedUp) {
-        return next != null ? next.getBackupFilenames(lastSegmentBackedUp) : Stream.empty();
+    public Stream<String> getBackupFilenames(long lastSegmentBackedUp, boolean includeActive) {
+        if (includeActive) {
+            Stream<String> filenames = getSegments().stream()
+                                                                  .map(s -> name(storageProperties.dataFile(context, s)));
+            return next != null ?
+                    Stream.concat(filenames, next.getBackupFilenames(lastSegmentBackedUp, includeActive)) :
+                    filenames;
+
+        }
+        return next != null ? next.getBackupFilenames(lastSegmentBackedUp, includeActive) : Stream.empty();
     }
 
     @Override
+    public long getFirstCompletedSegment() {
+         return next == null ? -1 : next.getFirstCompletedSegment();
+    }
+
+        @Override
     public CloseableIterator<SerializedEventWithToken> getGlobalIterator(long start) {
 
         return new CloseableIterator<SerializedEventWithToken>() {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexManager.java
@@ -48,6 +48,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import static io.axoniq.axonserver.localstorage.file.FileUtils.name;
+
 /**
  * Implementation of the index manager that creates 2 files per segment, an index file containing a map of aggregate
  * identifiers and the position of events for this aggregate and a bloom filter to quickly check if an aggregate occurs
@@ -488,8 +490,8 @@ public class StandardIndexManager implements IndexManager {
         return indexesDescending.stream()
                                 .filter(s -> s > lastSegmentBackedUp)
                                 .flatMap(s -> Stream.of(
-                                        storageProperties.index(context, s).getAbsolutePath(),
-                                        storageProperties.bloomFilter(context, s).getAbsolutePath()
+                                        name(storageProperties.index(context, s)),
+                                        name(storageProperties.bloomFilter(context, s))
                                 ));
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/BackupInfoRestController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/BackupInfoRestController.java
@@ -32,6 +32,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.axoniq.axonserver.util.StringUtils.sanitize;
+
 /**
  * REST Controller to retrieve files for backup and create backup of controldb.
  *
@@ -63,10 +65,12 @@ public class BackupInfoRestController {
             @RequestParam(value = "type") String type,
             @RequestParam(value = "lastSegmentBackedUp", required = false, defaultValue = "-1") long lastSegmentBackedUp,
             @ApiIgnore Principal principal) {
-        auditLog.info("[{}] Request for event store backup filenames. Context=\"{}\", type=\"{}\"",
-                      AuditLog.username(principal),
-                      context,
-                      type);
+        if (auditLog.isInfoEnabled()) {
+            auditLog.info("[{}] Request for event store backup filenames. Context=\"{}\", type=\"{}\"",
+                          AuditLog.username(principal),
+                          sanitize(context),
+                          sanitize(type));
+        }
 
         return localEventStore
                 .getBackupFilenames(context, EventType.valueOf(type), lastSegmentBackedUp, false)
@@ -79,10 +83,12 @@ public class BackupInfoRestController {
             @RequestParam(value = "type") String type,
             @RequestParam(value = "lastClosedSegmentBackedUp", required = false, defaultValue = "-1") long lastSegmentBackedUp,
             @ApiIgnore Principal principal) {
-        auditLog.info("[{}] Request for event store backup filenames. Context=\"{}\", type=\"{}\"",
-                      AuditLog.username(principal),
-                      context,
-                      type);
+        if (auditLog.isInfoEnabled()) {
+            auditLog.info("[{}] Request for event store backup filenames. Context=\"{}\", type=\"{}\"",
+                          AuditLog.username(principal),
+                          sanitize(context),
+                          sanitize(type));
+        }
 
         return new EventStoreBackupInfo(localEventStore.getFirstCompletedSegment(context, EventType.valueOf(type)),
                                                                              localEventStore

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/RecreateIndexTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/file/RecreateIndexTest.java
@@ -75,7 +75,7 @@ public class RecreateIndexTest {
     public void recreateIndex() {
         testSubject.init(true);
 
-        List<String> files = testSubject.getBackupFilenames(-1).collect(Collectors.toList());
+        List<String> files = testSubject.getBackupFilenames(-1, false).collect(Collectors.toList());
         assertEquals(6, files.size());
 
         AtomicInteger events = new AtomicInteger();


### PR DESCRIPTION
create new endpoint /v1/backup/eventstore to list all files to backup for a context, deprecates /v1/backup/filenames

the result from the new endpoint includes the current segment and a field for the last closed segment.