### PR TITLE
fix concurrency issue in notifyWritePositions

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/StorageCallback.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/StorageCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * Copyright (c) 2017-2022 AxonIQ B.V. and/or licensed to AxonIQ B.V.
  * under one or more contributor license agreements.
  *
  *  Licensed under the AxonIQ Open Source License Agreement v1.0;
@@ -13,8 +13,8 @@ package io.axoniq.axonserver.localstorage;
  * @author Marc Gathier
  */
 public interface StorageCallback {
-    boolean onCompleted(long firstToken);
+    boolean complete(long firstToken);
 
-    void onError(Throwable cause);
+    void error(Throwable cause);
 
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * Copyright (c) 2017-2022 AxonIQ B.V. and/or licensed to AxonIQ B.V.
  * under one or more contributor license agreements.
  *
  *  Licensed under the AxonIQ Open Source License Agreement v1.0;
@@ -12,12 +12,12 @@ package io.axoniq.axonserver.localstorage.file;
 import io.axoniq.axonserver.config.FileSystemMonitor;
 import io.axoniq.axonserver.exception.ErrorCode;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
-import io.axoniq.axonserver.localstorage.transformation.EventTransformer;
-import io.axoniq.axonserver.localstorage.transformation.EventTransformerFactory;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.localstorage.EventTypeContext;
 import io.axoniq.axonserver.localstorage.SerializedEventWithToken;
 import io.axoniq.axonserver.localstorage.StorageCallback;
+import io.axoniq.axonserver.localstorage.transformation.EventTransformer;
+import io.axoniq.axonserver.localstorage.transformation.EventTransformerFactory;
 import io.axoniq.axonserver.localstorage.transformation.ProcessedEvent;
 import io.axoniq.axonserver.localstorage.transformation.WrappedEvent;
 import io.axoniq.axonserver.metric.MeterFactory;
@@ -213,11 +213,11 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
             WritePosition writePosition = preparedTransaction.getWritePosition();
 
             synchronizer.register(writePosition, new StorageCallback() {
-                private final AtomicBoolean execute = new AtomicBoolean(true);
+                private final AtomicBoolean running = new AtomicBoolean();
 
                 @Override
-                public boolean onCompleted(long firstToken) {
-                    if (execute.getAndSet(false)) {
+                public boolean complete(long firstToken) {
+                    if (running.compareAndSet(false, true)) {
                         indexManager.addToActiveSegment(writePosition.segment, indexEntries);
                         completableFuture.complete(firstToken);
                         lastToken.set(firstToken + preparedTransaction.getEventList().size() - 1);
@@ -227,7 +227,7 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
                 }
 
                 @Override
-                public void onError(Throwable cause) {
+                public void error(Throwable cause) {
                     completableFuture.completeExceptionally(cause);
                 }
             });
@@ -421,9 +421,7 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
         }
         WritePosition writePosition;
         do {
-            writePosition = writePositionRef.getAndAccumulate(
-                    new WritePosition(nrOfEvents, totalSize),
-                    (prev, x) -> prev.incrementedWith(x.prevEntries, x.position));
+            writePosition = writePositionRef.getAndUpdate(prev -> prev.incrementedWith(nrOfEvents, totalSize));
 
             if (writePosition.isOverflow(totalSize)) {
                 // only one thread can be here

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
@@ -152,7 +152,7 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
         indexManager.addToActiveSegment(first, loadedEntries);
 
         buffer.putInt(buffer.position(), 0);
-        WritePosition writePosition = new WritePosition(sequence, buffer.position(), buffer, first);
+        WritePosition writePosition = new WritePosition(sequence, buffer.position(), buffer, first, 0);
         writePositionRef.set(writePosition);
         synchronizer.init(writePosition);
     }
@@ -423,7 +423,7 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
         do {
             writePosition = writePositionRef.getAndAccumulate(
                     new WritePosition(nrOfEvents, totalSize),
-                    (prev, x) -> prev.incrementedWith(x.sequence, x.position));
+                    (prev, x) -> prev.incrementedWith(x.sequence, x.position, nrOfEvents));
 
             if (writePosition.isOverflow(totalSize)) {
                 // only one thread can be here

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/PrimaryEventStore.java
@@ -423,7 +423,7 @@ public class PrimaryEventStore extends SegmentBasedEventStore {
         do {
             writePosition = writePositionRef.getAndAccumulate(
                     new WritePosition(nrOfEvents, totalSize),
-                    (prev, x) -> prev.incrementedWith(x.sequence, x.position, nrOfEvents));
+                    (prev, x) -> prev.incrementedWith(x.prevEntries, x.position));
 
             if (writePosition.isOverflow(totalSize)) {
                 // only one thread can be here

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/Synchronizer.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/Synchronizer.java
@@ -76,7 +76,7 @@ public class Synchronizer {
                     break;
                 }
 
-                if (writePosition.sequence > current.sequence + writePosition.entries) {
+                if (writePosition.sequence > current.sequence + writePosition.prevEntries) {
                     break;
                 }
 
@@ -84,7 +84,7 @@ public class Synchronizer {
                     updated.set(true);
 
                     if (canSyncAt(writePosition, current)) {
-                        syncAndCloseFile.add(currentRef.get());
+                        syncAndCloseFile.add(current);
                     }
                     iterator.remove();
                 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/WritePosition.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/WritePosition.java
@@ -26,7 +26,7 @@ public class WritePosition implements Comparable<WritePosition> {
     final int position;
     final WritableEventSource buffer;
     final Long segment;
-    public int prevEntries;
+    final int prevEntries;
 
     /**
      * @param sequence the sequence number of the first event in this block

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/WritePosition.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/WritePosition.java
@@ -12,6 +12,8 @@ package io.axoniq.axonserver.localstorage.file;
 import java.util.Comparator;
 
 /**
+ * Describes a block where the event store can write a transaction.
+ *
  * @author Marc Gathier
  */
 public class WritePosition implements Comparable<WritePosition> {
@@ -24,25 +26,39 @@ public class WritePosition implements Comparable<WritePosition> {
     final int position;
     final WritableEventSource buffer;
     final Long segment;
-    public int entries;
+    public int prevEntries;
 
-    public WritePosition(long sequence, int position) {
-        this(sequence, position, null, null, 0);
+    public WritePosition(long prevEntries, int position) {
+        this(0, position, null, null, (int) prevEntries);
     }
 
-    public WritePosition(long sequence, int position, WritableEventSource buffer, Long segment, int entries) {
+    /**
+     * @param sequence the sequence number of the first event in this blcok
+     * @param position the position of the block in the file
+     * @param buffer the buffer for writing the block
+     * @param segment the segment number containing the block
+     * @param prevEntries the number of events in the previous transaction
+     */
+    public WritePosition(long sequence, int position, WritableEventSource buffer, Long segment, int prevEntries) {
         this.sequence = sequence;
         this.position = position;
         this.buffer = buffer;
         this.segment = segment;
+        this.prevEntries = prevEntries;
     }
 
+    /**
+     * Creates a new version of the {@link WritePosition} linking to a new write buffer. Position is the initial position
+     * in the segment to start writing event data.
+     * @param buffer the write buffer for the new segment
+     * @return updated write position
+     */
     public WritePosition reset(WritableEventSource buffer) {
         return new WritePosition(sequence,
                                  SegmentBasedEventStore.VERSION_BYTES + SegmentBasedEventStore.FILE_OPTIONS_BYTES,
                                  buffer,
                                  sequence,
-                                 entries);
+                                 prevEntries);
     }
 
     boolean isOverflow(int transactionLength) {
@@ -63,14 +79,14 @@ public class WritePosition implements Comparable<WritePosition> {
         return this != INVALID && buffer != null && position + transactionLength + 4 < buffer.capacity();
     }
 
-    WritePosition incrementedWith(long sequence, int position, int nrOfEvents) {
+    WritePosition incrementedWith(int entries, int position) {
         if (this == INVALID || this.position > buffer.capacity()) {
             return INVALID;
         }
         return new WritePosition(
-                this.sequence + sequence,
+                this.sequence + entries,
                 this.position + position,
-                this.buffer, this.segment, nrOfEvents);
+                this.buffer, this.segment, entries);
     }
 
     boolean isComplete() {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/WritePosition.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/WritePosition.java
@@ -28,12 +28,8 @@ public class WritePosition implements Comparable<WritePosition> {
     final Long segment;
     public int prevEntries;
 
-    public WritePosition(long prevEntries, int position) {
-        this(0, position, null, null, (int) prevEntries);
-    }
-
     /**
-     * @param sequence the sequence number of the first event in this blcok
+     * @param sequence the sequence number of the first event in this block
      * @param position the position of the block in the file
      * @param buffer the buffer for writing the block
      * @param segment the segment number containing the block


### PR DESCRIPTION
fixes #495 

The iterator used to check the writePositions is only weakly consistent and may not see new entries in the underlying map.
If two writes call this operation in parallel, they should each check all completed write positions (only one of them will do the work).