### PR TITLE
Change and unify error codes for when the command or query queues are full

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/message/FlowControlQueues.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/FlowControlQueues.java
@@ -81,14 +81,16 @@ public class FlowControlQueues<T> {
         BlockingQueue<DestinationNode> destinationSegment = segments.computeIfAbsent(filterValue,
                                                                                      this::newQueueWithMetrics);
         if (destinationSegment.size() >= hardLimit) {
-            logger.warn("Reached hard limit on queue size of {}, priority of item failed to be added {}, hard limit {}.",
+            logger.warn("Reached hard limit on queue {} of size {}, priority of item failed to be added {}, hard limit {}.",
+                        filterValue,
                         destinationSegment.size(),
                         priority,
                         hardLimit);
             throw new MessagingPlatformException(errorCode, "Failed to add request to queue " + filterValue);
         }
         if (priority <= 0 && destinationSegment.size() >= softLimit) {
-            logger.warn("Reached soft limit on queue size of {}, priority of item failed to be added {}, soft limit {}.",
+            logger.warn("Reached soft limit on queue size {} of size {}, priority of item failed to be added {}, soft limit {}.",
+                        filterValue,
                         destinationSegment.size(),
                         priority,
                         softLimit);
@@ -96,7 +98,7 @@ public class FlowControlQueues<T> {
         }
         DestinationNode destinationNode = new DestinationNode(value);
         if (!destinationSegment.offer(destinationNode)) {
-            throw new MessagingPlatformException(ErrorCode.OTHER, "Failed to add request to queue " + filterValue);
+            throw new MessagingPlatformException(errorCode, "Failed to add request to queue " + filterValue);
         }
 
         if (logger.isTraceEnabled()) {
@@ -124,7 +126,7 @@ public class FlowControlQueues<T> {
                     Thread.currentThread().interrupt();
                     logger.debug("Interrupt during move");
                     throw new MessagingPlatformException(ErrorCode.OTHER,
-                                                         "Failed to add request to queue " + destination);
+                                                         "Failed to move request to queue " + destination);
                 }
             }
         });

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandDispatcher.java
@@ -71,7 +71,7 @@ public class CommandDispatcher {
                                                 queueCapacity,
                                                 BaseMetricName.AXON_APPLICATION_COMMAND_QUEUE_SIZE,
                                                 meterFactory,
-                                                ErrorCode.COMMAND_DISPATCH_ERROR);
+                                                ErrorCode.TOO_MANY_REQUESTS);
         metricRegistry.gauge(BaseMetricName.AXON_ACTIVE_COMMANDS, commandCache, ConstraintCache::size);
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/query/QueryDispatcher.java
@@ -74,7 +74,7 @@ public class QueryDispatcher {
                                              queueCapacity,
                                              BaseMetricName.AXON_APPLICATION_QUERY_QUEUE_SIZE,
                                              meterFactory,
-                                             ErrorCode.QUERY_DISPATCH_ERROR);
+                                             ErrorCode.TOO_MANY_REQUESTS);
         queryMetricsRegistry.gauge(BaseMetricName.AXON_ACTIVE_QUERIES, queryCache, ConstraintCache::size);
     }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/FlowControlQueuesTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/FlowControlQueuesTest.java
@@ -24,14 +24,16 @@ import static org.junit.Assert.*;
 public class FlowControlQueuesTest {
     private static final int SOFT_LIMIT_QUEUE_SIZE = 5;
     private FlowControlQueues<QueueElement> testSubject;
+    private ErrorCode errorCode;
 
     @Before
     public void setup() {
+        errorCode = ErrorCode.OTHER;
         testSubject = new FlowControlQueues<>(Comparator.comparing(QueueElement::getPrioKey),
                                               SOFT_LIMIT_QUEUE_SIZE,
                                               null,
                                               null,
-                                              ErrorCode.OTHER);
+                errorCode);
     }
 
     @Test
@@ -82,14 +84,15 @@ public class FlowControlQueuesTest {
         assertEquals("C", testSubject.take("one").prioKey);
     }
 
-    @Test(expected = MessagingPlatformException.class)
+    @Test
     public void queueSoftLimits() {
         testSubject.put("one", new QueueElement("A"));
         testSubject.put("one", new QueueElement("B"));
         testSubject.put("one", new QueueElement("C"));
         testSubject.put("one", new QueueElement("D"));
         testSubject.put("one", new QueueElement("E"));
-        testSubject.put("one", new QueueElement("F"), -1);
+
+        assertThrows(MessagingPlatformException.class, () -> testSubject.put("one", new QueueElement("F"), -1));
     }
 
     @Test(expected = MessagingPlatformException.class)

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandDispatcherTest.java
@@ -142,7 +142,7 @@ public class CommandDispatcherTest {
                                        responseObserver.onCompleted();
                                    });
         assertEquals(1, responseObserver.values().size());
-        assertNotEquals("", responseObserver.values().get(0).getErrorCode());
+        assertEquals(ErrorCode.TOO_MANY_REQUESTS.getCode(), responseObserver.values().get(0).getErrorCode());
     }
 
     @Test

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/QueryDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/QueryDispatcherTest.java
@@ -51,7 +51,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -180,7 +179,7 @@ public class QueryDispatcherTest {
         assertEquals(1, responseObserver.completedCount());
         assertTrue(queryCache.isEmpty());
         assertEquals(1, responseObserver.values().size());
-        assertNotEquals("", responseObserver.values().get(0).getErrorCode());
+        assertEquals(ErrorCode.TOO_MANY_REQUESTS.getCode(), responseObserver.values().get(0).getErrorCode());
         assertEquals(requestId, responseObserver.values().get(0).getRequestIdentifier());
     }
 


### PR DESCRIPTION
When Command and Query queues got full, Dispatching errors were reported which gave an impression that there was an issue instead of normal behaviour for throttling.

This PR will change this behaviour to send back `TOO_MANY_REQUESTS` errors to clearly indicate that the senders should slow down.