### PR TITLE
fix query connection not closed when the client completes the request stream

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
@@ -41,6 +41,7 @@ import io.axoniq.axonserver.queryparser.FunctionExpr;
 import io.axoniq.axonserver.queryparser.Numeric;
 import io.axoniq.axonserver.queryparser.Query;
 import io.axoniq.axonserver.queryparser.QueryElement;
+import io.axoniq.axonserver.util.StreamObserverUtils;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -351,7 +352,6 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
     @Override
     public void onCompleted() {
         close();
-        this.responseObserver.onCompleted();
     }
 
     private void close() {
@@ -359,6 +359,7 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
         pipeLine = null;
         Optional.ofNullable(senderRef.get())
                 .ifPresent(Sender::stop);
+        StreamObserverUtils.complete(responseObserver);
     }
 
     private class Sender {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserver.java
@@ -351,6 +351,7 @@ public class QueryEventsRequestStreamObserver implements StreamObserver<QueryEve
     @Override
     public void onCompleted() {
         close();
+        this.responseObserver.onCompleted();
     }
 
     private void close() {

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserverTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/query/QueryEventsRequestStreamObserverTest.java
@@ -76,6 +76,11 @@ public class QueryEventsRequestStreamObserverTest {
     }
 
     @Test
+    public void completedByCaller() throws ExecutionException, InterruptedException, TimeoutException {
+        testSubject.onCompleted();
+        completableResult.get(1, TimeUnit.SECONDS);
+    }
+    @Test
     public void onNextEvent() throws InterruptedException, ExecutionException, TimeoutException {
         doAnswer(invocation -> {
             String aggregateId = invocation.getArgument(0);


### PR DESCRIPTION
Complete the response stream when the request stream is completed.

#527 