### PR TITLE
fix read aggregate to stop searching if the last event has same sequence number as the last snapshot

### DIFF
--- a/axonserver/README.txt
+++ b/axonserver/README.txt
@@ -3,9 +3,21 @@ This is the Axon Server Standard Edition, version 4.5
 For information about the Axon Framework and Axon Server,
 visit https://docs.axoniq.io.
 
+Release Notes for version 4.5.16
+--------------------------------
+* Fix: reading aggregate events searches for older events when the last event sequence number
+  is the same as the snapshot sequence number
+* New property for index, axoniq.axonserver.event.segments-for-sequence-number-check, defines the number of segments
+  that Axon Server will check for events on an aggregate when an event with sequence number 0
+  is stored. The default value for this property is 10.
+  For performance reasons, if you increase this property to a value higher than 100 it is recommended
+  to also increase the axoniq.axonserver.event.max-bloom-filters-in-memory property.
+
 Release Notes for version 4.5.15
 --------------------------------
-* Fix: reading aggregate events hangs on JVM Error
+* Fix: reading aggregate events hangs on JVM Error, this includes a new property
+"axoniq.axonserver.event.aggregate.timeout" to set the timeout between two events returned by Axon Server.
+The default value for this property is 30 seconds.
 
 Release Notes for version 4.5.14
 --------------------------------

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventWriteStorage.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/EventWriteStorage.java
@@ -102,4 +102,8 @@ public class EventWriteStorage {
     public void cancelPendingTransactions() {
         storageTransactionManager.cancelPendingTransactions();
     }
+
+    public void clearSequenceNumberCache() {
+        storageTransactionManager.clearSequenceNumberCache();
+    }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/SegmentBasedEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/SegmentBasedEventStore.java
@@ -67,7 +67,6 @@ public abstract class SegmentBasedEventStore implements EventStorageEngine {
 
     public static final byte TRANSACTION_VERSION = 2;
     protected static final Logger logger = LoggerFactory.getLogger(SegmentBasedEventStore.class);
-    protected static final int MAX_SEGMENTS_FOR_SEQUENCE_NUMBER_CHECK = 10;
     protected static final int VERSION_BYTES = 1;
     protected static final int FILE_OPTIONS_BYTES = 4;
     protected static final int TX_CHECKSUM_BYTES = 4;
@@ -254,7 +253,7 @@ public abstract class SegmentBasedEventStore implements EventStorageEngine {
     @Override
     public Optional<Long> getLastSequenceNumber(String aggregateIdentifier, SearchHint[] hints) {
         return getLastSequenceNumber(aggregateIdentifier, contains(hints, SearchHint.RECENT_ONLY) ?
-                MAX_SEGMENTS_FOR_SEQUENCE_NUMBER_CHECK : Integer.MAX_VALUE, Long.MAX_VALUE);
+                storageProperties.segmentsForSequenceNumberCheck() : Integer.MAX_VALUE, Long.MAX_VALUE);
     }
 
     private <T> boolean contains(T[] values, T value) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexManager.java
@@ -428,8 +428,8 @@ public class StandardIndexManager implements IndexManager {
             }
             IndexEntries entries = activeIndexes.getOrDefault(segment, Collections.emptyMap()).get(aggregateId);
             if (entries != null) {
-                entries = addToResult(firstSequenceNumber, lastSequenceNumber, results, segment, entries);
-                maxResults -= entries.size();
+                int nrOfEntries = addToResult(firstSequenceNumber, lastSequenceNumber, results, segment, entries);
+                maxResults -= nrOfEntries;
                 if (allEntriesFound(firstSequenceNumber, maxResults, entries)) {
                     return results;
                 }
@@ -444,8 +444,8 @@ public class StandardIndexManager implements IndexManager {
             IndexEntries entries = getPositions(index, aggregateId);
             logger.debug("{}: lookupAggregate {} in segment {} found {}", context, aggregateId, index, entries);
             if (entries != null) {
-                entries = addToResult(firstSequenceNumber, lastSequenceNumber, results, index, entries);
-                maxResults -= entries.size();
+                int nrOfEntries = addToResult(firstSequenceNumber, lastSequenceNumber, results, index, entries);
+                maxResults -= nrOfEntries;
                 if (allEntriesFound(firstSequenceNumber, maxResults, entries)) {
                     return results;
                 }
@@ -456,13 +456,13 @@ public class StandardIndexManager implements IndexManager {
         return results;
     }
 
-    private IndexEntries addToResult(long firstSequenceNumber, long lastSequenceNumber,
+    private int addToResult(long firstSequenceNumber, long lastSequenceNumber,
                                      SortedMap<Long, IndexEntries> results, Long segment, IndexEntries entries) {
         entries = entries.range(firstSequenceNumber, lastSequenceNumber, EventType.SNAPSHOT.equals(eventType));
         if (!entries.isEmpty()) {
             results.put(segment, entries);
         }
-        return entries;
+        return entries.size();
     }
 
     private boolean allEntriesFound(long firstSequenceNumber, long maxResults, IndexEntries entries) {

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StorageProperties.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StorageProperties.java
@@ -120,6 +120,8 @@ public class StorageProperties implements Cloneable {
             Duration.ofDays(7)
     };
     private String indexFormat;
+    private int segmentsForSequenceNumberCheck = 10;
+
     public StorageProperties(SystemInfoProvider systemInfoProvider) {
         this.systemInfoProvider = systemInfoProvider;
     }
@@ -346,6 +348,9 @@ public class StorageProperties implements Cloneable {
         return systemInfoProvider.javaOnWindows();
     }
 
+    public void setSegmentsForSequenceNumberCheck(int segmentsForSequenceNumberCheck) {
+        this.segmentsForSequenceNumberCheck = segmentsForSequenceNumberCheck;
+    }
 
     public void setFlags(int flags) {
         this.flags = flags;
@@ -412,5 +417,9 @@ public class StorageProperties implements Cloneable {
         StorageProperties clone = cloneProperties();
         clone.retentionTime = retentionTime;
         return clone;
+    }
+
+    public int segmentsForSequenceNumberCheck() {
+        return segmentsForSequenceNumberCheck;
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/SingleInstanceTransactionManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/SingleInstanceTransactionManager.java
@@ -38,4 +38,9 @@ public class SingleInstanceTransactionManager implements StorageTransactionManag
     public Runnable reserveSequenceNumbers(List<Event> eventList) {
         return sequenceNumberCache.reserveSequenceNumbers(eventList, false);
     }
+
+    @Override
+    public void clearSequenceNumberCache() {
+        sequenceNumberCache.clear();
+    }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/StorageTransactionManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/transaction/StorageTransactionManager.java
@@ -40,4 +40,8 @@ public interface StorageTransactionManager {
     default void cancelPendingTransactions() {
 
     }
+
+    default void clearSequenceNumberCache() {
+
+    }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -282,7 +282,7 @@ public class EventDispatcher implements AxonServerClientService {
                                         .set(signal.get().getAggregateSequenceNumber());
                             }
                         })
-                        .timeout(Duration.ofSeconds(listEventsTimeoutMillis))
+                        .timeout(Duration.ofMillis(listEventsTimeoutMillis))
                         .onErrorMap(TimeoutException.class, e -> new MessagingPlatformException(LIST_AGGREGATE_EVENTS_TIMEOUT,
                                 "Timeout exception: No events were emitted from event store in last " + listEventsTimeoutMillis + "ms. Check the logs for virtual machine errors like OutOfMemoryError."))
                         .retryWhen(retrySpec

--- a/axonserver/src/test/java/io/axoniq/axonserver/localstorage/EventWriteStorageTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/localstorage/EventWriteStorageTest.java
@@ -1,0 +1,49 @@
+package io.axoniq.axonserver.localstorage;
+
+import io.axoniq.axonserver.exception.ErrorCode;
+import io.axoniq.axonserver.exception.MessagingPlatformException;
+import io.axoniq.axonserver.localstorage.file.PrimaryEventStore;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.*;
+
+public class EventWriteStorageTest {
+    @ClassRule
+    public static TemporaryFolder tempFolder = new TemporaryFolder();
+    private static TestInputStreamStorageContainer container;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        container = new TestInputStreamStorageContainer(tempFolder.getRoot(), embeddedDBProperties -> {
+            embeddedDBProperties.getEvent().setSegmentsForSequenceNumberCheck(100);
+            return embeddedDBProperties;
+        });
+        container.createDummyEvents(1000, 150, "sample");
+        container.getEventWriter().clearSequenceNumberCache();
+        PrimaryEventStore primaryEventStore = (PrimaryEventStore)container.getPrimary();
+        while( primaryEventStore.activeSegmentCount() > 1 ) {
+            Thread.sleep(10);
+        }
+
+    }
+
+    @Test
+    public void store() {
+        try {
+            container.createDummyEvents(1, 100, "sample");
+            fail("should not be able to store new event with sequence number 0 for existing aggregate");
+        } catch (MessagingPlatformException messagingPlatformException) {
+            assertEquals(ErrorCode.INVALID_SEQUENCE, messagingPlatformException.getErrorCode());
+        }
+    }
+
+    @AfterClass
+    public static void close() {
+        container.close();
+    }
+}


### PR DESCRIPTION
make the number of segments to check when a domain event with aggregate number 0 is stored configurable
fix the unit for the timeout in reading aggregates