### PR TITLE
Report client event processor metrics

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/ClientEventProcessorInfo.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/ClientEventProcessorInfo.java
@@ -20,14 +20,16 @@ public class ClientEventProcessorInfo {
     private final String clientId;
     private final String clientStreamId;
     private final String context;
+    private final String component;
     private final EventProcessorInfo eventProcessorInfo;
 
     public ClientEventProcessorInfo(String clientId, String clientStreamId, String context,
-                                    EventProcessorInfo eventProcessorInfo) {
+                                    String component, EventProcessorInfo eventProcessorInfo) {
 
         this.clientId = clientId;
         this.clientStreamId = clientStreamId;
         this.context = context;
+        this.component = component;
         this.eventProcessorInfo = eventProcessorInfo;
     }
 
@@ -41,6 +43,10 @@ public class ClientEventProcessorInfo {
 
     public String getContext() {
         return context;
+    }
+
+    public String getComponent() {
+        return component;
     }
 
     public EventProcessorInfo getEventProcessorInfo() {

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/ProcessorEventPublisher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/ProcessorEventPublisher.java
@@ -73,10 +73,12 @@ public class ProcessorEventPublisher {
 
     private void publishEventProcessorStatus(PlatformService.ClientComponent clientComponent,
                                              PlatformInboundInstruction inboundInstruction) {
-        ClientEventProcessorInfo processorStatus =
-                new ClientEventProcessorInfo(clientComponent.getClientId(),
-                                             clientComponent.getClientStreamId(),
-                                             clientComponent.getContext(), inboundInstruction.getEventProcessorInfo());
+        ClientEventProcessorInfo processorStatus = new ClientEventProcessorInfo(
+                clientComponent.getClientId(),
+                clientComponent.getClientStreamId(),
+                clientComponent.getContext(),
+                clientComponent.getComponent(),
+                inboundInstruction.getEventProcessorInfo());
         applicationEventPublisher.publishEvent(new EventProcessorStatusUpdate(processorStatus));
     }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/listener/ClientProcessor.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/listener/ClientProcessor.java
@@ -31,6 +31,13 @@ public interface ClientProcessor extends ComponentItem, Iterable<SegmentStatus> 
      */
     String context();
 
+    /**
+     * Returns the component name of the client that is connected
+     *
+     * @return The component name of the client that is connected
+     */
+    String component();
+
     EventProcessorInfo eventProcessorInfo();
 
     default boolean running() {

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/listener/ClientProcessorMapping.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/listener/ClientProcessorMapping.java
@@ -32,6 +32,11 @@ public interface ClientProcessorMapping {
             }
 
             @Override
+            public String component() {
+                return component;
+            }
+
+            @Override
             public EventProcessorInfo eventProcessorInfo() {
                 return eventProcessorInfo;
             }

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorKey.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorKey.java
@@ -1,0 +1,59 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import io.micrometer.core.instrument.Tags;
+
+/**
+ * Represents a unique event processor, based on the context, component and name.
+ *
+ * @author Mitchell Herrijgers
+ */
+public class EventProcessorKey {
+    private final String context;
+    private final String component;
+    private final String name;
+
+    public EventProcessorKey(String context, String component, String name) {
+        this.context = context;
+        this.component = component;
+        this.name = name;
+    }
+
+    public Tags asMetricTags() {
+        return Tags
+                .of("context", context)
+                .and("component", component)
+                .and("name", name);
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public String getComponent() {
+        return component;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final EventProcessorKey that = (EventProcessorKey) o;
+
+        if (!context.equals(that.context)) return false;
+        if (!component.equals(that.component)) return false;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = context.hashCode();
+        result = 31 * result + component.hashCode();
+        result = 31 * result + name.hashCode();
+        return result;
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorMetricPublisher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorMetricPublisher.java
@@ -1,0 +1,30 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+
+import java.util.List;
+
+/**
+ * Represents a component that publishes metrics for event processors, based on the {@link EventProcessorKey}.
+ *
+ * @author Mitchell Herrijgers
+ */
+public interface EventProcessorMetricPublisher {
+    /**
+     * The implementing class should publish the result of a computation to a metric, such as a
+     * {@link io.micrometer.core.instrument.Gauge} or {@link io.micrometer.core.instrument.Counter}.
+     * <p>
+     * All relevant instances of {@link EventProcessorInfo} are provided to execute this computation.
+     *
+     * @param key        The key, unique for each event processor.
+     * @param processors The processor info's to base the computation on.
+     */
+    void publishFor(EventProcessorKey key, List<EventProcessorInfo> processors);
+
+    /**
+     * The implementing class should clean up any lingering data for this processor. Called when an event processor is not seen for over an hour.
+     *
+     * @param key The key, unique for each event processor.
+     */
+    void cleanup(EventProcessorKey key);
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorMonitoringProvider.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorMonitoringProvider.java
@@ -1,0 +1,84 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import io.axoniq.axonserver.applicationevents.EventProcessorEvents;
+import io.axoniq.axonserver.component.processor.ClientEventProcessorInfo;
+import io.axoniq.axonserver.component.processor.listener.ClientProcessor;
+import io.axoniq.axonserver.component.processor.listener.ClientProcessors;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Mastermind for all event processor metrics. Any metrics should be provided by a bean implementing {@link EventProcessorMetricPublisher}.
+ * The {@link EventProcessorMonitoringProvider} orchestrates the publishing of metrics, and instructs publishers to clean
+ * up if a processor has not been seen in over an hour.
+ *
+ * @author Mitchell Herrijgers
+ */
+@Service
+public class EventProcessorMonitoringProvider {
+    private final Clock clock;
+    private final ClientProcessors clientProcessors;
+    private final List<EventProcessorMetricPublisher> publishers;
+
+    private final Map<EventProcessorKey, Instant> registryMap = new ConcurrentHashMap<>();
+
+    public EventProcessorMonitoringProvider(Clock clock,
+                                            ClientProcessors clientProcessors,
+                                            List<EventProcessorMetricPublisher> publishers) {
+        this.clock = clock;
+        this.clientProcessors = clientProcessors;
+        this.publishers = publishers;
+    }
+
+    @EventListener
+    public void on(EventProcessorEvents.EventProcessorStatusUpdated event) {
+        final ClientEventProcessorInfo info = event.eventProcessorStatus();
+        final EventProcessorKey key = new EventProcessorKey(
+                info.getContext(),
+                info.getComponent(),
+                info.getEventProcessorInfo().getProcessorName()
+        );
+
+        registryMap.put(key, clock.instant());
+        update(key);
+    }
+
+    private void update(final EventProcessorKey key) {
+        final List<EventProcessorInfo> eventProcessorInfo = StreamSupport
+                .stream(clientProcessors.spliterator(), false)
+                .filter(p -> getEventProcessorKey(p).equals(key))
+                .map(ClientProcessor::eventProcessorInfo)
+                .filter(EventProcessorInfo::getRunning)
+                .collect(Collectors.toList());
+        publishers.forEach(p -> p.publishFor(key, eventProcessorInfo));
+    }
+
+    private EventProcessorKey getEventProcessorKey(final ClientProcessor p) {
+        final String component = p.component();
+        final String processorName = p.eventProcessorInfo().getProcessorName();
+        final String context = p.context();
+        return new EventProcessorKey(context, component, processorName);
+    }
+
+    @Scheduled(fixedRate = 60000)
+    public void cleanup() {
+        final Instant limit = clock.instant().minus(1, ChronoUnit.HOURS);
+        registryMap.forEach((key, instant) -> {
+            if (instant.isBefore(limit)) {
+                publishers.forEach(p -> p.cleanup(key));
+                registryMap.remove(key);
+            }
+        });
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorMonitoringUtils.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorMonitoringUtils.java
@@ -1,0 +1,28 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.axoniq.axonserver.metric.BaseMetricName;
+import io.axoniq.axonserver.metric.MeterFactory;
+
+/**
+ * Utilities for use in event processor monitoring.
+ *
+ * @author Mitchell Herrijgers
+ */
+public interface EventProcessorMonitoringUtils {
+    /**
+     * Creates an {@link AtomicDouble} and registers it to the provided {@link MeterFactory} with the {@link BaseMetricName}.
+     *
+     * @param key          Key of the processor, to create tags.
+     * @param metric       The {@link BaseMetricName} to register.
+     * @param meterFactory The {@link MeterFactory} to use.
+     *
+     * @return An {@link AtomicDouble}, watched by the metric implementation. Each {@link AtomicDouble#set(double)}
+     * will be reflected in the metrics.
+     */
+    static AtomicDouble createMetric(final EventProcessorKey key, final BaseMetricName metric, final MeterFactory meterFactory) {
+        final AtomicDouble atomicDouble = new AtomicDouble();
+        meterFactory.gauge(metric, key.asMetricTags(), atomicDouble, AtomicDouble::get);
+        return atomicDouble;
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorSegmentMetricsPublisher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorSegmentMetricsPublisher.java
@@ -1,0 +1,60 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+import io.axoniq.axonserver.metric.BaseMetricName;
+import io.axoniq.axonserver.metric.MeterFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+import static io.axoniq.axonserver.component.processor.monitoring.EventProcessorMonitoringUtils.createMetric;
+
+/**
+ * Publishes the {@link BaseMetricName#AXON_EVENT_PROCESSOR_SEGMENTS_UNCLAIMED} metric. If this value is higher than 0,
+ * segments are unclaimed and events are not being handled by the projection.
+ * <p>
+ * This metric can be used to detect event processors in error, being stuck or not having enough threads available.
+ *
+ * @author Mitchell Herrijgers
+ */
+@Component
+public class EventProcessorSegmentMetricsPublisher implements EventProcessorMetricPublisher {
+    private final MeterFactory meterFactory;
+    private final Map<EventProcessorKey, AtomicDouble> unclaimedMap = new HashMap<>();
+
+    public EventProcessorSegmentMetricsPublisher(final MeterFactory meterFactory) {
+        this.meterFactory = meterFactory;
+    }
+
+    @Override
+    public void publishFor(final EventProcessorKey key, final List<EventProcessorInfo> processors) {
+        final AtomicDouble metric = unclaimedMap.computeIfAbsent(key, k -> createMetric(k, BaseMetricName.AXON_EVENT_PROCESSOR_SEGMENTS_UNCLAIMED, meterFactory));
+        metric.set(determineUnclaimedSegments(processors));
+    }
+
+    private double determineUnclaimedSegments(final List<EventProcessorInfo> processors) {
+        Set<Integer> ids = new HashSet<>();
+        final double claimedSegments = processors.stream()
+                .map(EventProcessorInfo::getSegmentStatusList)
+                .flatMap(Collection::stream)
+                .filter(c -> StringUtils.isEmpty(c.getErrorState()))
+                .mapToDouble(segmentStatus -> {
+                    int segmentId = segmentStatus.getSegmentId();
+                    if (ids.contains(segmentId)) {
+                        return 0d;
+                    }
+                    ids.add(segmentId);
+                    return 1d / segmentStatus.getOnePartOf();
+                })
+                .sum();
+        return 1 - claimedSegments;
+    }
+
+
+    @Override
+    public void cleanup(final EventProcessorKey key) {
+        unclaimedMap.remove(key);
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorThreadMetricsPublisher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorThreadMetricsPublisher.java
@@ -1,0 +1,57 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+import io.axoniq.axonserver.message.event.EventDispatcher;
+import io.axoniq.axonserver.metric.BaseMetricName;
+import io.axoniq.axonserver.metric.MeterFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.axoniq.axonserver.component.processor.monitoring.EventProcessorMonitoringUtils.createMetric;
+
+/**
+ * Publishes two metrics:
+ * - {@link BaseMetricName#AXON_EVENT_PROCESSOR_THREADS_ACTIVE}: The amount of threads active for this processor.
+ * - {@link BaseMetricName#AXON_EVENT_PROCESSOR_THREADS_AVAILABLE}: The amount of threads available for this processor.
+ * <p>
+ * These metrics can be used together in monitoring to visualize the amount of active segments, as well as the amount
+ * of segments that can still be claimed. The {@link BaseMetricName#AXON_EVENT_PROCESSOR_THREADS_AVAILABLE} is excluded
+ * for Pooled Streaming event processors, since these have a (nearly) unlimited amount of segments, throwing off monitoring.
+ *
+ * @author Mitchell Herrijgers
+ */
+@Component
+public class EventProcessorThreadMetricsPublisher implements EventProcessorMetricPublisher {
+    private final MeterFactory meterFactory;
+    private final Map<EventProcessorKey, AtomicDouble> activeMap = new HashMap<>();
+    private final Map<EventProcessorKey, AtomicDouble> availableMap = new HashMap<>();
+
+    public EventProcessorThreadMetricsPublisher(final MeterFactory meterFactory) {
+        this.meterFactory = meterFactory;
+    }
+
+    @Override
+    public void publishFor(final EventProcessorKey key, final List<EventProcessorInfo> processors) {
+        AtomicDouble activeMetric = activeMap.computeIfAbsent(key, k -> createMetric(k, BaseMetricName.AXON_EVENT_PROCESSOR_THREADS_ACTIVE, meterFactory));
+        int activeThreads = processors.stream().mapToInt(EventProcessorInfo::getActiveThreads).sum();
+        activeMetric.set(activeThreads);
+
+        final boolean isPooledStreaming = processors.stream().anyMatch(p -> p.getMode().equals("Pooled Streaming"));
+        if (!isPooledStreaming) {
+            AtomicDouble availableMetric = availableMap.computeIfAbsent(key, k -> createMetric(k, BaseMetricName.AXON_EVENT_PROCESSOR_THREADS_AVAILABLE, meterFactory));
+            int availableThreads = processors.stream().mapToInt(EventProcessorInfo::getAvailableThreads).sum();
+            availableMetric.set(availableThreads);
+        }
+    }
+
+    @Override
+    public void cleanup(final EventProcessorKey key) {
+        activeMap.remove(key);
+        availableMap.remove(key);
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorTokenMetricsPublisher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorTokenMetricsPublisher.java
@@ -1,0 +1,65 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+import io.axoniq.axonserver.message.event.EventDispatcher;
+import io.axoniq.axonserver.metric.BaseMetricName;
+import io.axoniq.axonserver.metric.MeterFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.axoniq.axonserver.component.processor.monitoring.EventProcessorMonitoringUtils.createMetric;
+
+/**
+ * Publishes two metrics:
+ * - {@link BaseMetricName#AXON_EVENT_PROCESSOR_EVENT_POSITION}: The lowest token position across all claimed segments of this processor.
+ * - {@link BaseMetricName#AXON_EVENT_PROCESSOR_EVENT_LAG}: The highest amount any claimed segment is behind the head of this processor.
+ * <p>
+ * These metrics can be used together in monitoring to find a non-performing projection, or track how far a replay currently is.
+ *
+ * @author Mitchell Herrijgers
+ */
+@Component
+public class EventProcessorTokenMetricsPublisher implements EventProcessorMetricPublisher {
+    private final EventDispatcher eventDispatcher;
+    private final MeterFactory meterFactory;
+    private final Map<EventProcessorKey, AtomicDouble> lowestTokenPositionMap = new HashMap<>();
+    private final Map<EventProcessorKey, AtomicDouble> eventLagMap = new HashMap<>();
+
+    public EventProcessorTokenMetricsPublisher(final EventDispatcher eventDispatcher, final MeterFactory meterFactory) {
+        this.eventDispatcher = eventDispatcher;
+        this.meterFactory = meterFactory;
+    }
+
+    @Override
+    public void publishFor(final EventProcessorKey key, final List<EventProcessorInfo> processors) {
+        final AtomicDouble tokenPositionMetric = lowestTokenPositionMap.computeIfAbsent(key, k -> createMetric(k, BaseMetricName.AXON_EVENT_PROCESSOR_EVENT_POSITION, meterFactory));
+        final AtomicDouble eventLagMetric = eventLagMap.computeIfAbsent(key, k -> createMetric(k, BaseMetricName.AXON_EVENT_PROCESSOR_EVENT_LAG, meterFactory));
+
+        long lowestTokenPosition = determineLowestTokenPosition(processors);
+        final long headToken = eventDispatcher.getNrOfEvents(key.getContext());
+        final long eventLag = headToken - lowestTokenPosition;
+
+        tokenPositionMetric.set(lowestTokenPosition);
+        eventLagMetric.set(eventLag);
+    }
+
+    @Override
+    public void cleanup(final EventProcessorKey key) {
+        lowestTokenPositionMap.remove(key);
+        eventLagMap.remove(key);
+    }
+
+    private long determineLowestTokenPosition(final List<EventProcessorInfo> processors) {
+        return processors.stream()
+                .map(EventProcessorInfo::getSegmentStatusList)
+                .flatMap(Collection::stream)
+                .mapToLong(EventProcessorInfo.SegmentStatus::getTokenPosition)
+                .min()
+                .orElse(0);
+    }
+}

--- a/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/event/EventDispatcher.java
@@ -293,7 +293,7 @@ public class EventDispatcher {
         trackingEventProcessors.forEach((client, infos) -> {
             if (client.getContext().equals(context)) {
                 List<Long> status = infos.stream().map(EventTrackerInfo::getLastToken).collect(Collectors.toList());
-                trackers.put(client.toString(), status);
+                trackers.put(client.getClientStreamId(), status);
             }
         });
         return trackers;

--- a/axonserver/src/main/java/io/axoniq/axonserver/metric/BaseMetricName.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/metric/BaseMetricName.java
@@ -57,6 +57,15 @@ public enum BaseMetricName implements MetricName {
      * Metric for the rate of snapshots stored (tags: context)
      */
     AXON_SNAPSHOTS("axon.snapshot", "Number of snapshots stored"),
+    /**
+     * Metrics for tracking event processors in client applications. Tags: context, component, name
+     */
+    AXON_EVENT_PROCESSOR_SEGMENTS_UNCLAIMED("axon.processor.segments.unclaimed", "Percentage of segments that are unclaimed"),
+    AXON_EVENT_PROCESSOR_EVENT_POSITION("axon.processor.events.position", "Minimum token position of all claimed segments"),
+    AXON_EVENT_PROCESSOR_EVENT_LAG("axon.processor.events.lag", "How many events the projection is behind the head, based on the minimum token position for all segments"),
+    AXON_EVENT_PROCESSOR_THREADS_ACTIVE("axon.processor.threads.active", "Number of threads active for the processor"),
+    AXON_EVENT_PROCESSOR_THREADS_AVAILABLE("axon.processor.threads.available", "Number of threads available for the processor"),
+
     AXON_GLOBAL_SUBSCRIPTION_TOTAL("axon.GlobalSubscriptionMetricRegistry.total",
                                    "Total number of subscription queries subscribed"),
     AXON_GLOBAL_SUBSCRIPTION_UPDATES("axon.GlobalSubscriptionMetricRegistry.updates",

--- a/axonserver/src/main/java/io/axoniq/axonserver/metric/MeterFactory.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/metric/MeterFactory.java
@@ -27,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
 
 /**
  * Service to create rate based meters. Rate meters are implemented using dropwizard meters, and exposed by defining

--- a/axonserver/src/test/java/io/axoniq/axonserver/admin/eventprocessor/requestprocessor/DistributedEventProcessorTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/admin/eventprocessor/requestprocessor/DistributedEventProcessorTest.java
@@ -61,6 +61,11 @@ public class DistributedEventProcessorTest {
             }
 
             @Override
+            public String component() {
+                return "component";
+            }
+
+            @Override
             public EventProcessorInfo eventProcessorInfo() {
                 return EventProcessorInfo.newBuilder()
                                          .setMode(mode)

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/EventProcessorStatusRefreshTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/EventProcessorStatusRefreshTest.java
@@ -125,6 +125,7 @@ public class EventProcessorStatusRefreshTest {
                         client,
                         client,
                         "context",
+                        "component",
                         EventProcessorInfo.newBuilder().setProcessorName(processorName).build()),
                 false);
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/listener/FakeClientProcessor.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/listener/FakeClientProcessor.java
@@ -76,6 +76,11 @@ public class FakeClientProcessor implements ClientProcessor {
     }
 
     @Override
+    public String component() {
+        return "component";
+    }
+
+    @Override
     public EventProcessorInfo eventProcessorInfo() {
         return eventProcessorInfo;
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/listener/ProcessorsInfoTargetTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/listener/ProcessorsInfoTargetTest.java
@@ -37,13 +37,13 @@ public class ProcessorsInfoTargetTest {
                                                              .setProcessorName("Name")
                                                              .build();
         ClientEventProcessorInfo clientEventProcessorInfo = new ClientEventProcessorInfo("client", "client",
-                                                                                         "context",
-                                                                                         processorInfo);
+                                                                                         "context", "component", processorInfo);
         EventProcessorStatusUpdate event = new EventProcessorStatusUpdate(clientEventProcessorInfo);
         EventProcessorEvents.EventProcessorStatusUpdated updatedEvent = testSubject
                 .onEventProcessorStatusChange(event);
         assertEquals("client", updatedEvent.eventProcessorStatus().getClientId());
         assertEquals("context", updatedEvent.eventProcessorStatus().getContext());
+        assertEquals("component", updatedEvent.eventProcessorStatus().getComponent());
         ClientProcessor clientProcessor = StreamSupport.stream(Spliterators.spliterator(testSubject.iterator(), 100, 0),
                                                                false).
                                                                filter(cp -> cp.clientId().equals("client"))

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorKeyTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorKeyTest.java
@@ -1,0 +1,31 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import io.micrometer.core.instrument.Tags;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventProcessorKeyTest {
+    @Test
+    void hashCodeAndEqualsWorkCorrectly() {
+        final EventProcessorKey baseKey = new EventProcessorKey("context", "component", "name");
+        final EventProcessorKey sameKey = new EventProcessorKey("context", "component", "name");
+        final EventProcessorKey otherKey = new EventProcessorKey("context", "component2", "otherName");
+
+        assertEquals(baseKey, sameKey);
+        assertNotEquals(baseKey, otherKey);
+
+        assertEquals(baseKey.hashCode(), sameKey.hashCode());
+        assertNotEquals(baseKey.hashCode(), otherKey.hashCode());
+    }
+
+    @Test
+    void createsCorrectTags() {
+        final EventProcessorKey key = new EventProcessorKey("default", "my-microservice", "processor-name");
+        final Tags tags = key.asMetricTags();
+
+        assertTrue(tags.stream().anyMatch(tag -> tag.getKey().equals("context") && tag.getValue().equals("default")));
+        assertTrue(tags.stream().anyMatch(tag -> tag.getKey().equals("component") && tag.getValue().equals("my-microservice")));
+        assertTrue(tags.stream().anyMatch(tag -> tag.getKey().equals("name") && tag.getValue().equals("processor-name")));
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorMonitoringProviderTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorMonitoringProviderTest.java
@@ -1,0 +1,106 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import io.axoniq.axonserver.applicationevents.EventProcessorEvents;
+import io.axoniq.axonserver.component.processor.ClientEventProcessorInfo;
+import io.axoniq.axonserver.component.processor.listener.ClientProcessor;
+import io.axoniq.axonserver.component.processor.listener.ClientProcessors;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+class EventProcessorMonitoringProviderTest {
+    private final EventProcessorMetricPublisher publisher = Mockito.mock(EventProcessorMetricPublisher.class);
+    private final Clock clock = Mockito.mock(Clock.class);
+
+    private EventProcessorMonitoringProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        ClientProcessors clientProcessors = () -> generateProcessors().iterator();
+        provider = new EventProcessorMonitoringProvider(clock, clientProcessors, Collections.singletonList(publisher));
+        setTime(Instant.EPOCH);
+    }
+
+    private void setTime(Instant instant) {
+        when(clock.instant()).thenReturn(instant);
+    }
+
+    @Test
+    void callsPublishersWithCorrectItemsOnUpdate() {
+        final ArgumentCaptor<List<EventProcessorInfo>> argumentCaptor = ArgumentCaptor.forClass((Class) List.class);
+
+        EventProcessorKey key = new EventProcessorKey("contextOne", "componentTwo", "processorThree");
+        provider.on(createEvent("contextOne", "componentTwo", "processorThree"));
+        Mockito.verify(publisher).publishFor(eq(key), argumentCaptor.capture());
+
+        List<EventProcessorInfo> value = argumentCaptor.getValue();
+        assertTrue(value.stream().allMatch(EventProcessorInfo::getRunning));
+        assertTrue(value.stream().allMatch(i -> i.getProcessorName().equals("processorThree")));
+        assertEquals(1, value.size());
+    }
+
+    @Test
+    void cleansUpAfterAnHour() {
+        provider.on(createEvent("contextOne", "componentTwo", "processorThree"));
+
+        provider.cleanup();
+
+        verify(publisher, never()).cleanup(any());
+
+        setTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS).plus(1, ChronoUnit.SECONDS));
+        provider.cleanup();
+        verify(publisher).cleanup(any());
+    }
+
+    private ClientProcessor createProcessor(String context, String component, String processorName, boolean running) {
+        final ClientProcessor mock = Mockito.mock(ClientProcessor.class);
+        final EventProcessorInfo info = EventProcessorInfo.newBuilder()
+                .setRunning(running)
+                .setProcessorName(processorName)
+                .build();
+        when(mock.eventProcessorInfo()).thenReturn(info);
+        when(mock.context()).thenReturn(context);
+        when(mock.component()).thenReturn(component);
+
+        return mock;
+    }
+
+    private EventProcessorEvents.EventProcessorStatusUpdated createEvent(String context, String component, String processorName) {
+        final EventProcessorInfo info = EventProcessorInfo.newBuilder()
+                .setProcessorName(processorName)
+                .build();
+        return new EventProcessorEvents.EventProcessorStatusUpdated(new ClientEventProcessorInfo(
+                "", "", context, component, info
+        ), false);
+    }
+
+    private List<ClientProcessor> generateProcessors() {
+        List<ClientProcessor> processors = new LinkedList<>();
+        Arrays.asList("contextOne", "contextTwo", "contextThree").forEach(context -> {
+            Arrays.asList("componentOne", "componentTwo", "componentThree").forEach(component -> {
+                Arrays.asList("processorOne", "processorTwo", "processorThree").forEach(name -> {
+                    processors.add(createProcessor(context, component, name, true));
+                    processors.add(createProcessor(context, component, name, false));
+                });
+            });
+        });
+        return processors;
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorSegmentMetricsPublisherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorSegmentMetricsPublisherTest.java
@@ -1,0 +1,87 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+import io.axoniq.axonserver.metric.BaseMetricName;
+import io.axoniq.axonserver.metric.MeterFactory;
+import io.micrometer.core.instrument.Gauge;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EventProcessorSegmentMetricsPublisherTest {
+    private final MeterFactory meterFactory = mock(MeterFactory.class);
+    private final EventProcessorSegmentMetricsPublisher publisher = new EventProcessorSegmentMetricsPublisher(meterFactory);
+    private final AtomicReference<AtomicDouble> segmentMetricValue = new AtomicReference<>();
+
+    @BeforeEach
+    void setUp() {
+        when(meterFactory.gauge(eq(BaseMetricName.AXON_EVENT_PROCESSOR_SEGMENTS_UNCLAIMED), any(), any(), any())).thenAnswer(invocationOnMock -> {
+            final AtomicDouble argument = invocationOnMock.getArgument(2, AtomicDouble.class);
+            segmentMetricValue.set(argument);
+            return Mockito.mock(Gauge.class);
+        });
+    }
+
+    @Test
+    void unclaimedSegmentsIsOneWhenThereAreNoSegments() {
+        publisher.publishFor(mock(EventProcessorKey.class), Collections.emptyList());
+
+        assertNotNull(segmentMetricValue.get());
+        assertEquals(1d, segmentMetricValue.get().get());
+    }
+
+    @Test
+    void unclaimedSegmentsIsZeroWhenSingleIsClaimed() {
+        publisher.publishFor(mock(EventProcessorKey.class), singletonList(EventProcessorInfo.newBuilder()
+                .addSegmentStatus(EventProcessorInfo.SegmentStatus.newBuilder().setSegmentId(0).setOnePartOf(1).build())
+                .build()));
+
+        assertNotNull(segmentMetricValue.get());
+        assertEquals(0d, segmentMetricValue.get().get());
+    }
+
+    @Test
+    void unclaimedSegmentsIsQuarterWhenSomeAreClaimed() {
+        publisher.publishFor(mock(EventProcessorKey.class), singletonList(EventProcessorInfo.newBuilder()
+                .addSegmentStatus(EventProcessorInfo.SegmentStatus.newBuilder().setSegmentId(1).setOnePartOf(4).build())
+                .addSegmentStatus(EventProcessorInfo.SegmentStatus.newBuilder().setSegmentId(2).setOnePartOf(2).build())
+                .build()));
+
+        assertNotNull(segmentMetricValue.get());
+        assertEquals(0.25d, segmentMetricValue.get().get());
+    }
+
+    @Test
+    void unclaimedSegmentsDoesNotCountSegmentsWithSameIdTwice() {
+        publisher.publishFor(mock(EventProcessorKey.class), singletonList(EventProcessorInfo.newBuilder()
+                .addSegmentStatus(EventProcessorInfo.SegmentStatus.newBuilder().setSegmentId(1).setOnePartOf(4).build())
+                .addSegmentStatus(EventProcessorInfo.SegmentStatus.newBuilder().setSegmentId(1).setOnePartOf(4).build())
+                .addSegmentStatus(EventProcessorInfo.SegmentStatus.newBuilder().setSegmentId(2).setOnePartOf(2).build())
+                .build()));
+
+        assertNotNull(segmentMetricValue.get());
+        assertEquals(0.25d, segmentMetricValue.get().get());
+    }
+
+    @Test
+    void unclaimedSegmentsExcludesSegmentsInErrorState() {
+        publisher.publishFor(mock(EventProcessorKey.class), singletonList(EventProcessorInfo.newBuilder()
+                .addSegmentStatus(EventProcessorInfo.SegmentStatus.newBuilder().setSegmentId(1).setOnePartOf(4).build())
+                .addSegmentStatus(EventProcessorInfo.SegmentStatus.newBuilder().setSegmentId(2).setOnePartOf(2).setErrorState("MyException: Blabla").build())
+                .build()));
+
+        assertNotNull(segmentMetricValue.get());
+        assertEquals(0.75d, segmentMetricValue.get().get());
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorThreadMetricsPublisherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorThreadMetricsPublisherTest.java
@@ -1,0 +1,69 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+import io.axoniq.axonserver.metric.BaseMetricName;
+import io.axoniq.axonserver.metric.MeterFactory;
+import io.micrometer.core.instrument.Gauge;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EventProcessorThreadMetricsPublisherTest {
+    private final MeterFactory meterFactory = mock(MeterFactory.class);
+    private final EventProcessorThreadMetricsPublisher publisher = new EventProcessorThreadMetricsPublisher(meterFactory);
+    private final AtomicReference<AtomicDouble> activeMetricValue = new AtomicReference<>();
+    private final AtomicReference<AtomicDouble> availableMetricValue = new AtomicReference<>();
+
+    @BeforeEach
+    void setUp() {
+        when(meterFactory.gauge(eq(BaseMetricName.AXON_EVENT_PROCESSOR_THREADS_ACTIVE), any(), any(), any())).thenAnswer(invocationOnMock -> {
+            final AtomicDouble argument = invocationOnMock.getArgument(2, AtomicDouble.class);
+            activeMetricValue.set(argument);
+            return Mockito.mock(Gauge.class);
+        });
+        when(meterFactory.gauge(eq(BaseMetricName.AXON_EVENT_PROCESSOR_THREADS_AVAILABLE), any(), any(), any())).thenAnswer(invocationOnMock -> {
+            final AtomicDouble argument = invocationOnMock.getArgument(2, AtomicDouble.class);
+            availableMetricValue.set(argument);
+            return Mockito.mock(Gauge.class);
+        });
+    }
+
+    @Test
+    void addsActiveAndAvailableThreads() {
+        publisher.publishFor(mock(EventProcessorKey.class), Arrays.asList(
+                EventProcessorInfo.newBuilder().setActiveThreads(1).setAvailableThreads(2).build(),
+                EventProcessorInfo.newBuilder().setActiveThreads(1).setAvailableThreads(2).build(),
+                EventProcessorInfo.newBuilder().setActiveThreads(1).setAvailableThreads(2).build(),
+                EventProcessorInfo.newBuilder().setActiveThreads(1).setAvailableThreads(2).build(),
+                EventProcessorInfo.newBuilder().setActiveThreads(1).setAvailableThreads(2).build()
+        ));
+
+        assertEquals(5d, activeMetricValue.get().get());
+        assertEquals(10d, availableMetricValue.get().get());
+    }
+
+    @Test
+    void skipsAvailableMetricsWhenPooledStreaming() {
+        publisher.publishFor(mock(EventProcessorKey.class), Arrays.asList(
+                EventProcessorInfo.newBuilder().setMode("Pooled Streaming").setActiveThreads(1).setAvailableThreads(2).build(),
+                EventProcessorInfo.newBuilder().setMode("Pooled Streaming").setActiveThreads(1).setAvailableThreads(2).build(),
+                EventProcessorInfo.newBuilder().setMode("Pooled Streaming").setActiveThreads(1).setAvailableThreads(2).build(),
+                EventProcessorInfo.newBuilder().setMode("Pooled Streaming").setActiveThreads(1).setAvailableThreads(2).build(),
+                EventProcessorInfo.newBuilder().setMode("Pooled Streaming").setActiveThreads(1).setAvailableThreads(2).build()
+        ));
+
+        assertNull(availableMetricValue.get());
+    }
+}

--- a/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorTokenMetricsPublisherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/component/processor/monitoring/EventProcessorTokenMetricsPublisherTest.java
@@ -1,0 +1,80 @@
+package io.axoniq.axonserver.component.processor.monitoring;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
+import io.axoniq.axonserver.message.event.EventDispatcher;
+import io.axoniq.axonserver.metric.BaseMetricName;
+import io.axoniq.axonserver.metric.MeterFactory;
+import io.micrometer.core.instrument.Gauge;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EventProcessorTokenMetricsPublisherTest {
+    private final MeterFactory meterFactory = mock(MeterFactory.class);
+    private final EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+    private final EventProcessorTokenMetricsPublisher publisher = new EventProcessorTokenMetricsPublisher(eventDispatcher, meterFactory);
+    private final AtomicReference<AtomicDouble> lowestPositionValue = new AtomicReference<>();
+    private final AtomicReference<AtomicDouble> eventLagValue = new AtomicReference<>();
+
+    final EventProcessorKey key = mock(EventProcessorKey.class);
+
+    @BeforeEach
+    void setUp() {
+        when(meterFactory.gauge(eq(BaseMetricName.AXON_EVENT_PROCESSOR_EVENT_POSITION), any(), any(), any())).thenAnswer(invocationOnMock -> {
+            final AtomicDouble argument = invocationOnMock.getArgument(2, AtomicDouble.class);
+            lowestPositionValue.set(argument);
+            return Mockito.mock(Gauge.class);
+        });
+        when(meterFactory.gauge(eq(BaseMetricName.AXON_EVENT_PROCESSOR_EVENT_LAG), any(), any(), any())).thenAnswer(invocationOnMock -> {
+            final AtomicDouble argument = invocationOnMock.getArgument(2, AtomicDouble.class);
+            eventLagValue.set(argument);
+            return Mockito.mock(Gauge.class);
+        });
+        when(key.getContext()).thenReturn("myContext");
+        when(eventDispatcher.getNrOfEvents("myContext")).thenReturn(1000L);
+    }
+
+    @Test
+    void determinesLowestTokenPositionAndLag() {
+        publisher.publishFor(key, Arrays.asList(
+                EventProcessorInfo.newBuilder().addSegmentStatus(
+                        EventProcessorInfo.SegmentStatus.newBuilder().setTokenPosition(900).build()
+                ).build(),
+                EventProcessorInfo.newBuilder().addSegmentStatus(
+                        EventProcessorInfo.SegmentStatus.newBuilder().setTokenPosition(800).build()
+                ).build(),
+                EventProcessorInfo.newBuilder().addSegmentStatus(
+                        EventProcessorInfo.SegmentStatus.newBuilder().setTokenPosition(950).build()
+                ).build(),
+                EventProcessorInfo.newBuilder().addSegmentStatus(
+                        EventProcessorInfo.SegmentStatus.newBuilder().setTokenPosition(970).build()
+                ).build(),
+                EventProcessorInfo.newBuilder().addSegmentStatus(
+                        EventProcessorInfo.SegmentStatus.newBuilder().setTokenPosition(890).build()
+                ).build()
+        ));
+
+        assertEquals(800d, lowestPositionValue.get().get());
+        assertEquals(200d, eventLagValue.get().get());
+    }
+
+    @Test
+    void determinesZeroWhenNoSegments() {
+        publisher.publishFor(key, emptyList());
+
+        assertEquals(0d, lowestPositionValue.get().get());
+        assertEquals(1000d, eventLagValue.get().get());
+    }
+}


### PR DESCRIPTION
As request from a customer and very convenient feature, this PR introduces Event processor metrics so dashboards can be built. 

Such a dashboard could look like this, based on the PR:
![image](https://user-images.githubusercontent.com/3278878/186627267-bf27a01c-2fb7-4285-b2bd-f2e06b335da6.png)

# Metrics introduced

**Token Position**: The token position of the event processor. The value is the lowest position of any claimed segment.
**Event Lag**: The amount of events the projection is behind the head of the event store.The value is based on the token position metric and the current event store position.

**Unclaimed segments**: The percentage (between 0-1 for each unique processor) of unclaimed segment size. So, if there are 4 segments and 1 is unclaimed, the value is 0.25. 

**Active threads**: The amount of active threads/segments for this processor
**Available threads**: Amount of threads still available. Can be split if higher than 0. Disabled for pooled streaming processors since they are (almost) limitless (32768). 

# Exposure

The metrics are exposed using the `/actuator/metric` endpoint and `/actuator/prometheus`:
```
axon_processor_events_lag{axonserver="morlack-laptop",component="axoniq-hotel-booking",context="default",name="room-availability",} 2693.0
axon_processor_events_lag{axonserver="morlack-laptop",component="axoniq-hotel-booking",context="default",name="room-checkout",} 2693.0
axon_processor_events_lag{axonserver="morlack-laptop",component="axoniq-hotel-booking",context="default",name="payment",} 2693.0
axon_processor_events_lag{axonserver="morlack-laptop",component="axoniq-hotel-booking",context="default",name="account",} 2693.0
axon_processor_events_lag{axonserver="morlack-laptop",component="axoniq-hotel-inventory",context="default",name="room",} 0.0
axon_processor_events_lag{axonserver="morlack-laptop",component="axoniq-hotel-booking",context="default",name="room-cleaning",} 2693.0
axon_processor_events_lag{axonserver="morlack-laptop",component="axoniq-hotel-booking",context="default",name="BookingInventorySaga",} 2693.0
```