### PR TITLE
Clean-up event stream operation

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/LocalEventStore.java
@@ -1005,6 +1005,9 @@ public class LocalEventStore implements io.axoniq.axonserver.message.event.Event
 
         @Override
         public SerializedEvent decorateEvent(SerializedEvent serializedEvent) {
+            if (eventInterceptors.noReadInterceptors(unitOfWork.contextName())) {
+                return serializedEvent;
+            }
             try {
                 Event event = serializedEvent.isSnapshot() ?
                         eventInterceptors.readSnapshot(serializedEvent.asEvent(), unitOfWork) :

--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/TrackingEventProcessorManager.java
@@ -215,6 +215,7 @@ public class TrackingEventProcessorManager {
 
         private int sendNext() {
             if (!running) {
+                StreamObserverUtils.complete(eventStream);
                 throw new MessagingPlatformException(ErrorCode.OTHER,
                                                      context + ":Tracking event processor stopped for " + client);
             }
@@ -244,7 +245,7 @@ public class TrackingEventProcessorManager {
             } catch (IllegalStateException ex) {
                 // closed during iterating events
             } catch (Exception ex) {
-                running = false;
+                close();
                 sendError(ex);
             }
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/event/EventDispatcherTest.java
@@ -9,7 +9,6 @@
 
 package io.axoniq.axonserver.message.event;
 
-import io.axoniq.axonserver.applicationevents.TopologyEvents;
 import io.axoniq.axonserver.exception.MessagingPlatformException;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.EventWithToken;
@@ -273,11 +272,6 @@ public class EventDispatcherTest {
                     .expectNextCount(1L)
                     .verifyComplete();
         assertEquals(1, eventStoreWithoutLeaderCalls.get());
-
-        testSubject.on(new TopologyEvents.ApplicationDisconnected(DEFAULT_CONTEXT,
-                                                                  "myComponent",
-                                                                  "sampleClient", "test"));
-        assertTrue(testSubject.eventTrackerStatus(DEFAULT_CONTEXT).isEmpty());
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <gson.version>2.9.0</gson.version>
         <axonserver-plugin-api.version>4.6.0</axonserver-plugin-api.version>
         <axonserver.api.version>4.6.0</axonserver.api.version>
-        <flow.control.version>1.1</flow.control.version>
+        <flow.control.version>1.2-SNAPSHOT</flow.control.version>
         <spring-boot.version>2.7.1</spring-boot.version>
     </properties>
 


### PR DESCRIPTION
clean up events operation, callback in EventTrackerInfo is never called as ApplicationDisconnected listener checks based on clientStreamId and map is based on clientId. ApplicationDisconnected is not needed anyway.

prevent parsing serialized events if there are no read listeners. update flow control version.