### PR TITLE
apply filter for given context name for list of processors per application

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/svg/mapping/Applications.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/svg/mapping/Applications.java
@@ -14,7 +14,6 @@ import io.axoniq.axonserver.topology.Topology;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
@@ -25,6 +24,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toSet;
@@ -128,8 +128,8 @@ public class Applications implements Function<String, Stream<Application>> {
 
                                    @Override
                                    public int instances() {
-                                       return entry.getValue().stream().findFirst().map(apps -> apps.getValue().size())
-                                                   .orElse(0);
+                                       return entry.getValue().stream().mapToInt(apps -> apps.getValue().size())
+                                               .sum();
                                    }
 
                                    @Override

--- a/axonserver/src/main/resources/static/js/overview.js
+++ b/axonserver/src/main/resources/static/js/overview.js
@@ -13,6 +13,7 @@ globals.pageView = new Vue(
                 component: null,
                 displayStyle: "diagram",
                 context: null,
+                disableOptions: false,
                 title: null,
                 activeContext: "_all",
                 webSocketInfo: globals.webSocketInfo,
@@ -61,6 +62,7 @@ globals.pageView = new Vue(
                     this.component = component;
                     this.context = context;
                     this.title = title;
+                    this.disableOptions = true;
                 },
 
                 showDiagram() {
@@ -74,6 +76,7 @@ globals.pageView = new Vue(
                     this.component = null;
                     this.context = null;
                     this.title = null;
+                    this.disableOptions = false;
                 }
             }
         });

--- a/axonserver/src/main/resources/static/overview.html
+++ b/axonserver/src/main/resources/static/overview.html
@@ -151,12 +151,12 @@
     <div>
         <span v-if="isEnterprise()">
             Active context:
-        <select v-model="activeContext" @change="initOverview">
+        <select v-model="activeContext" @change="initOverview" :disabled="disableOptions">
             <option value="_all">All</option>
             <option v-for="n in contexts">{{ n }}</option>
         </select>
             Display:
-        <select v-model="displayStyle">
+        <select v-model="displayStyle" :disabled="disableOptions">
             <option value="diagram">Diagram</option>
             <option value="list">List</option>
         </select>
@@ -228,7 +228,7 @@
 
     <div v-if="component">
         <h2>
-            <span @click="component = ''" class="icon"><i class="fas fa-arrow-circle-left"></i></span> Application
+            <span @click="deselectComponent()" class="icon"><i class="fas fa-arrow-circle-left"></i></span> Application
             details for {{ title }}
         </h2>
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/admin/eventprocessor/api/FakeEventProcessor.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/admin/eventprocessor/api/FakeEventProcessor.java
@@ -12,9 +12,9 @@ package io.axoniq.axonserver.admin.eventprocessor.api;
 import io.axoniq.axonserver.component.processor.EventProcessorIdentifier;
 import io.axoniq.axonserver.topology.Topology;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * Fake implementation of {@link EventProcessor} for test purpose


### PR DESCRIPTION
also:
disable the context and display dropdown lists while showing application details, as changing the value does not have an impact. correct the value for number of instances of an application when there are 2 instances of the same application connected, but they are connected to different contexts.