### PR TITLE
Prevent an exception could stop the delivery of instructions.

### DIFF
--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/GrpcFlowControlledDispatcherListenerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/GrpcFlowControlledDispatcherListenerTest.java
@@ -33,7 +33,10 @@ public class GrpcFlowControlledDispatcherListenerTest {
     @Before
     public void setUp() throws Exception {
         FlowControlQueues<String> queues = new FlowControlQueues<>();
-        testSubject = new GrpcFlowControlledDispatcherListener<String,String>(queues, "queue1", new FakeStreamObserver<String>(), 1) {
+        testSubject = new GrpcFlowControlledDispatcherListener<String, String>(queues,
+                                                                               "queue1",
+                                                                               new FakeStreamObserver<>(),
+                                                                               1) {
 
             @Override
             protected boolean send(String message) {
@@ -68,7 +71,10 @@ public class GrpcFlowControlledDispatcherListenerTest {
         queues.put("MyQueueName", "Final");
         CountDownLatch countDownLatch = new CountDownLatch(6);
         GrpcFlowControlledDispatcherListener<String, String> listener =
-                new GrpcFlowControlledDispatcherListener<>(queues, "MyQueueName", new FakeStreamObserver<>(), 2) {
+                new GrpcFlowControlledDispatcherListener<String, String>(queues,
+                                                                         "MyQueueName",
+                                                                         new FakeStreamObserver<>(),
+                                                                         2) {
 
                     @Override
                     protected boolean send(String message) {

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/GrpcFlowControlledDispatcherListenerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/GrpcFlowControlledDispatcherListenerTest.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 
@@ -58,7 +57,6 @@ public class GrpcFlowControlledDispatcherListenerTest {
     @Test
     public void testExceptionOccurredSendingNextInstruction() throws InterruptedException {
         FlowControlQueues<String> queues = new FlowControlQueues<>();
-        AtomicInteger sendMessages = new AtomicInteger();
         queues.put("MyQueueName", "One");
         queues.put("MyQueueName", "Two");
         queues.put("MyQueueName", "Three");

--- a/axonserver/src/test/java/io/axoniq/axonserver/grpc/GrpcFlowControlledDispatcherListenerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/grpc/GrpcFlowControlledDispatcherListenerTest.java
@@ -1,6 +1,6 @@
 /*
- *  Copyright (c) 2017-2021 AxonIQ B.V. and/or licensed to AxonIQ B.V.
- *  under one or more contributor license agreements.
+ * Copyright (c) 2017-2023 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ * under one or more contributor license agreements.
  *
  *  Licensed under the AxonIQ Open Source License Agreement v1.0;
  *  you may not use this file except in compliance with the license.
@@ -15,6 +15,10 @@ import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.Assert.*;
 
 /**
@@ -22,13 +26,15 @@ import static org.junit.Assert.*;
  * @since 4.5.8
  */
 public class GrpcFlowControlledDispatcherListenerTest {
-    private GrpcFlowControlledDispatcherListener<String,String> testSubject;
+
+    private final Logger logger = LoggerFactory.getLogger("test");
+    private GrpcFlowControlledDispatcherListener<String, String> testSubject;
 
     @Before
     public void setUp() throws Exception {
         FlowControlQueues<String> queues = new FlowControlQueues<>();
         testSubject = new GrpcFlowControlledDispatcherListener<String,String>(queues, "queue1", new FakeStreamObserver<String>(), 1) {
-            private final Logger logger = LoggerFactory.getLogger("test");
+
             @Override
             protected boolean send(String message) {
                 return false;
@@ -44,5 +50,45 @@ public class GrpcFlowControlledDispatcherListenerTest {
     @Test
     public void waiting() {
         assertEquals(0, testSubject.waiting());
+    }
+
+    @Test
+    public void testExceptionOccurredSendingNextInstruction() throws InterruptedException {
+        FlowControlQueues<String> queues = new FlowControlQueues<>();
+        AtomicInteger sendMessages = new AtomicInteger();
+        queues.put("MyQueueName", "One");
+        queues.put("MyQueueName", "Two");
+        queues.put("MyQueueName", "Three");
+        queues.put("MyQueueName", "specialOne");
+        queues.put("MyQueueName", "Four");
+        queues.put("MyQueueName", "specialOne");
+        queues.put("MyQueueName", "Five");
+        queues.put("MyQueueName", "specialOne");
+        queues.put("MyQueueName", "Six");
+        queues.put("MyQueueName", "Final");
+        CountDownLatch countDownLatch = new CountDownLatch(6);
+        GrpcFlowControlledDispatcherListener<String, String> listener =
+                new GrpcFlowControlledDispatcherListener<>(queues, "MyQueueName", new FakeStreamObserver<>(), 2) {
+
+                    @Override
+                    protected boolean send(String message) {
+                        logger.warn(Thread.currentThread().getName());
+                        if (message.equals("specialOne")) {
+                            throw new RuntimeException();
+                        }
+                        logger.warn(message);
+
+                        countDownLatch.countDown();
+                        return true;
+                    }
+
+                    @Override
+                    protected Logger getLogger() {
+                        return logger;
+                    }
+                };
+        listener.addPermits(10);
+        countDownLatch.await(1, TimeUnit.SECONDS);
+        assertEquals(0, countDownLatch.getCount());
     }
 }


### PR DESCRIPTION
During the processing of the queue items, any exception occurred sending the instruction could stop the processing of remaining instructions. This fix prevents it by catching the exception occurring in processing. 
The PR contains also a logging improvement.