### PR TITLE
fix check for visible contexts when the LDAP extension is used

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/api/common.kt
+++ b/axonserver/src/main/java/io/axoniq/axonserver/api/common.kt
@@ -1,3 +1,12 @@
+/*
+ *  Copyright (c) 2017-2023 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ *  under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
 package io.axoniq.axonserver.api
 
 /**
@@ -8,6 +17,7 @@ package io.axoniq.axonserver.api
  * @since 4.6
  */
 interface Authentication {
+
     /**
      * Returns the username of the authenticated user
      */
@@ -26,4 +36,15 @@ interface Authentication {
      */
     fun application(): Boolean
 
+    /**
+     * Returns {@code true} if the authentication is managed by Axon Server internally.
+     */
+    fun isLocallyManaged(): Boolean
+
+    /**
+     * Returns {@code true} if the authentication contains any role for the given context. Also returns {@code true} if the
+     * authentication contains a role for any context ('*').
+     * @param the name of the context
+     */
+    fun hasAnyRole(context: String): Boolean
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/transport/grpc/GrpcAuthentication.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/transport/grpc/GrpcAuthentication.java
@@ -40,11 +40,13 @@ public class GrpcAuthentication implements Authentication {
 
     @Override
     public boolean hasRole(@NotNull String role, @NotNull String context) {
+        String roleAtContext = format("%s@%s", role, context);
+        String roleAtAny = format("%s@%s", role, context);
         return authentication.getAuthorities()
                              .stream()
                              .anyMatch(grantedAuthority ->
-                                               grantedAuthority.getAuthority().equals(format("%s@%s", role, context)) ||
-                                                       grantedAuthority.getAuthority().equals(format("%s@*", role)));
+                                               grantedAuthority.getAuthority().equals(roleAtContext) ||
+                                                       grantedAuthority.getAuthority().equals(roleAtAny));
     }
 
     @Override
@@ -59,10 +61,11 @@ public class GrpcAuthentication implements Authentication {
 
     @Override
     public boolean hasAnyRole(@NotNull String context) {
+        String atContext = format("@%s", context);
         return authentication.getAuthorities()
                              .stream()
                              .anyMatch(grantedAuthority ->
-                                               grantedAuthority.getAuthority().endsWith(format("@%s", context)) ||
+                                               grantedAuthority.getAuthority().endsWith(atContext) ||
                                                        grantedAuthority.getAuthority().endsWith("@*"));
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/transport/grpc/GrpcAuthentication.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/transport/grpc/GrpcAuthentication.java
@@ -1,3 +1,12 @@
+/*
+ *  Copyright (c) 2017-2023 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ *  under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
 package io.axoniq.axonserver.transport.grpc;
 
 import io.axoniq.axonserver.api.Authentication;
@@ -33,12 +42,28 @@ public class GrpcAuthentication implements Authentication {
     public boolean hasRole(@NotNull String role, @NotNull String context) {
         return authentication.getAuthorities()
                              .stream()
-                             .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals(format("%s@%s", role, context)));
+                             .anyMatch(grantedAuthority ->
+                                               grantedAuthority.getAuthority().equals(format("%s@%s", role, context)) ||
+                                                       grantedAuthority.getAuthority().equals(format("%s@*", role)));
     }
 
     @Override
     public boolean application() {
         return true;
+    }
+
+    @Override
+    public boolean isLocallyManaged() {
+        return true;
+    }
+
+    @Override
+    public boolean hasAnyRole(@NotNull String context) {
+        return authentication.getAuthorities()
+                             .stream()
+                             .anyMatch(grantedAuthority ->
+                                               grantedAuthority.getAuthority().endsWith(format("@%s", context)) ||
+                                                       grantedAuthority.getAuthority().endsWith("@*"));
     }
 }
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/transport/rest/PrincipalAuthentication.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/transport/rest/PrincipalAuthentication.java
@@ -1,8 +1,18 @@
+/*
+ *  Copyright (c) 2017-2023 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ *  under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
 package io.axoniq.axonserver.transport.rest;
 
 import io.axoniq.axonserver.access.ApplicationBinding;
 import io.axoniq.axonserver.api.Authentication;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.security.core.userdetails.User;
 
 import java.security.Principal;
 import javax.annotation.Nonnull;
@@ -32,10 +42,19 @@ public class PrincipalAuthentication implements Authentication {
     @Override
     public boolean hasRole(@NotNull String role, @NotNull String context) {
         if (principal instanceof org.springframework.security.core.Authentication) {
-            return ((org.springframework.security.core.Authentication)principal).getAuthorities()
-                    .stream()
-                    .anyMatch(grantedAuthority -> grantedAuthority.getAuthority()
-                                                                  .equals(format("%s@%s", role, context)));
+            return ((org.springframework.security.core.Authentication) principal).getAuthorities()
+                                                                                 .stream()
+                                                                                 .anyMatch(grantedAuthority ->
+                                                                                                   grantedAuthority.getAuthority()
+                                                                                                                   .equals(format(
+                                                                                                                           "%s@%s",
+                                                                                                                           role,
+                                                                                                                           context))
+                                                                                                           ||
+                                                                                                           grantedAuthority.getAuthority()
+                                                                                                                           .equals(format(
+                                                                                                                                   "%s@*",
+                                                                                                                                   role)));
         }
         return false;
     }
@@ -43,7 +62,7 @@ public class PrincipalAuthentication implements Authentication {
     @Override
     public boolean application() {
         return (principal instanceof org.springframework.security.core.Authentication
-                && ((org.springframework.security.core.Authentication)principal).getPrincipal() instanceof ApplicationBinding);
+                && ((org.springframework.security.core.Authentication) principal).getPrincipal() instanceof ApplicationBinding);
     }
 
     @Override
@@ -51,5 +70,33 @@ public class PrincipalAuthentication implements Authentication {
         return "PrincipalAuthentication{" +
                 "principal=" + principal +
                 '}';
+    }
+
+    @Override
+    public boolean isLocallyManaged() {
+        return application() || isLocalUser();
+    }
+
+    private boolean isLocalUser() {
+        return (principal instanceof org.springframework.security.core.Authentication
+                && ((org.springframework.security.core.Authentication) principal).getPrincipal() instanceof User);
+    }
+
+    @Override
+    public boolean hasAnyRole(@NotNull String context) {
+        if (principal instanceof org.springframework.security.core.Authentication) {
+            return ((org.springframework.security.core.Authentication) principal).getAuthorities()
+                                                                                 .stream()
+                                                                                 .anyMatch(grantedAuthority ->
+                                                                                                   grantedAuthority.getAuthority()
+                                                                                                                   .endsWith(
+                                                                                                                           format("@%s",
+                                                                                                                                  context))
+                                                                                                           ||
+                                                                                                           grantedAuthority.getAuthority()
+                                                                                                                           .endsWith(
+                                                                                                                                   "@*"));
+        }
+        return false;
     }
 }

--- a/axonserver/src/main/java/io/axoniq/axonserver/transport/rest/PrincipalAuthentication.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/transport/rest/PrincipalAuthentication.java
@@ -42,19 +42,14 @@ public class PrincipalAuthentication implements Authentication {
     @Override
     public boolean hasRole(@NotNull String role, @NotNull String context) {
         if (principal instanceof org.springframework.security.core.Authentication) {
-            return ((org.springframework.security.core.Authentication) principal).getAuthorities()
-                                                                                 .stream()
-                                                                                 .anyMatch(grantedAuthority ->
-                                                                                                   grantedAuthority.getAuthority()
-                                                                                                                   .equals(format(
-                                                                                                                           "%s@%s",
-                                                                                                                           role,
-                                                                                                                           context))
-                                                                                                           ||
-                                                                                                           grantedAuthority.getAuthority()
-                                                                                                                           .equals(format(
-                                                                                                                                   "%s@*",
-                                                                                                                                   role)));
+            String roleAtContext = format("%s@%s", role, context);
+            String roleAtAny = format("%s@*", role);
+            return ((org.springframework.security.core.Authentication) principal)
+                    .getAuthorities()
+                    .stream()
+                    .anyMatch(grantedAuthority ->
+                                      grantedAuthority.getAuthority().equals(roleAtContext)
+                                              || grantedAuthority.getAuthority().equals(roleAtAny));
         }
         return false;
     }
@@ -85,17 +80,13 @@ public class PrincipalAuthentication implements Authentication {
     @Override
     public boolean hasAnyRole(@NotNull String context) {
         if (principal instanceof org.springframework.security.core.Authentication) {
-            return ((org.springframework.security.core.Authentication) principal).getAuthorities()
-                                                                                 .stream()
-                                                                                 .anyMatch(grantedAuthority ->
-                                                                                                   grantedAuthority.getAuthority()
-                                                                                                                   .endsWith(
-                                                                                                                           format("@%s",
-                                                                                                                                  context))
-                                                                                                           ||
-                                                                                                           grantedAuthority.getAuthority()
-                                                                                                                           .endsWith(
-                                                                                                                                   "@*"));
+            String atContext = format("@%s", context);
+            return ((org.springframework.security.core.Authentication) principal)
+                    .getAuthorities()
+                    .stream()
+                    .anyMatch(grantedAuthority ->
+                                      grantedAuthority.getAuthority().endsWith(atContext)
+                                              || grantedAuthority.getAuthority().endsWith("@*"));
         }
         return false;
     }

--- a/axonserver/src/test/java/io/axoniq/axonserver/util/AuthenticatedUser.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/util/AuthenticatedUser.java
@@ -1,3 +1,12 @@
+/*
+ *  Copyright (c) 2017-2023 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ *  under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
+
 package io.axoniq.axonserver.util;
 
 import io.axoniq.axonserver.api.Authentication;
@@ -25,5 +34,15 @@ public class AuthenticatedUser implements Authentication {
     @Override
     public boolean application() {
         return false;
+    }
+
+    @Override
+    public boolean isLocallyManaged() {
+        return true;
+    }
+
+    @Override
+    public boolean hasAnyRole(@NotNull String context) {
+        return true;
     }
 }


### PR DESCRIPTION
when authorization is done using the LDAP extension, users are not stored in the users tables in Axon Server. To check the roles, use the information from the authentication object. Authorization changes in LDAP are only seen after a new login in Axon Server.