### PR TITLE
fix filter for nodes returned

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/PublicRestController.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/PublicRestController.java
@@ -93,7 +93,7 @@ public class PublicRestController {
             "For _admin nodes the result contains all nodes, for non _admin nodes the"
                     + "result only contains nodes from contexts available on this node and the _admin nodes.")
     public List<JsonServerNode> getClusterNodes() {
-        return axonServerProvider.apply(c -> true)
+        return axonServerProvider.apply(null)
                                  .map(JsonServerNode::new)
                                  .sorted(Comparator.comparing(JsonServerNode::getName)).collect(Collectors.toList());
     }

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/svg/mapping/AxonServers.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/svg/mapping/AxonServers.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2017-2019 AxonIQ B.V. and/or licensed to AxonIQ B.V.
- * under one or more contributor license agreements.
+ *  Copyright (c) 2017-2023 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ *  under one or more contributor license agreements.
  *
  *  Licensed under the AxonIQ Open Source License Agreement v1.0;
  *  you may not use this file except in compliance with the license.
@@ -41,7 +41,8 @@ public class AxonServers implements Function<Predicate<String>, Stream<AxonServe
     @Nonnull
     public Stream<AxonServer> apply(Predicate<String> contextFilter) {
         return topology.nodes()
-                       .filter(n -> n.getContextNames().stream().anyMatch(contextFilter::test))
+                       .filter(n -> n.getContextNames().isEmpty() || n.getContextNames().stream()
+                                                                      .anyMatch(contextFilter::test))
                        .sorted(Comparator.comparing(AxonServerNode::getName))
                        .map(node -> (AxonServer) new AxonServer() {
 

--- a/axonserver/src/main/java/io/axoniq/axonserver/rest/svg/mapping/AxonServers.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/rest/svg/mapping/AxonServers.java
@@ -41,8 +41,8 @@ public class AxonServers implements Function<Predicate<String>, Stream<AxonServe
     @Nonnull
     public Stream<AxonServer> apply(Predicate<String> contextFilter) {
         return topology.nodes()
-                       .filter(n -> n.getContextNames().isEmpty() || n.getContextNames().stream()
-                                                                      .anyMatch(contextFilter::test))
+                       .filter(n -> contextFilter == null || n.getContextNames().stream()
+                                                              .anyMatch(contextFilter::test))
                        .sorted(Comparator.comparing(AxonServerNode::getName))
                        .map(node -> (AxonServer) new AxonServer() {
 
@@ -59,7 +59,7 @@ public class AxonServers implements Function<Predicate<String>, Stream<AxonServe
                                      @Override
                                      public List<String> contexts() {
                                          return node.getContextNames().stream()
-                                                    .filter(contextFilter::test)
+                                                    .filter(c -> contextFilter == null || contextFilter.test(c))
                                                     .sorted().collect(
                                                          Collectors.toList());
                                      }


### PR DESCRIPTION
Nodes without a context were always filtered out. Update the implementation of the cluster endpoint to always return all nodes.