### PR TITLE
Dont mark context as ephemeral if snapshot storage has black hole tier

### DIFF
--- a/axonserver/src/main/resources/static/context.html
+++ b/axonserver/src/main/resources/static/context.html
@@ -465,7 +465,7 @@
                     });
             },
             isEphemeral(context) {
-                return Object.values(context.metaData).some(value => value === 'black_hole');
+                return Object.keys(context.metaData).some(key => key.startsWith("event.tier") && context.metaData[key] === 'black_hole');
             },
             isMultiTierConfigured() {
                 for (let nodeRole of Object.keys(this.chosenEventTiers)) {


### PR DESCRIPTION
While writing blog and section about deleting snapshots I realised that marking context as ephemeral if snapshot has black hole tier is wrong move. ephemeral context is only context that deletes events