### PR TITLE
Fix flyway error on upgrade

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/config/AxonServerStandardConfiguration.java
@@ -59,6 +59,7 @@ import org.springframework.beans.factory.BeanCreationNotAllowedException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.system.DiskSpaceHealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationListener;
@@ -94,6 +95,14 @@ public class AxonServerStandardConfiguration {
     @ConditionalOnMissingBean(StorageTransactionManagerFactory.class)
     public StorageTransactionManagerFactory storageTransactionManagerFactory() {
         return new DefaultStorageTransactionManagerFactory();
+    }
+
+    @Bean
+    public FlywayMigrationStrategy cleanMigrateStrategy() {
+        return flyway -> {
+            flyway.repair();
+            flyway.migrate();
+        };
     }
 
     @Bean

--- a/axonserver/src/main/resources/db/migration/V7_1__transformation_authorization.sql
+++ b/axonserver/src/main/resources/db/migration/V7_1__transformation_authorization.sql
@@ -7,13 +7,26 @@
  *
  */
 
-insert into roles (role, description) values ('TRANSFORM', 'Transform events.');
-insert into roles (role, description) values ('TRANSFORM_ADMIN', 'Applies transformation.');
+/*
+ *  Copyright (c) 2017-2023 AxonIQ B.V. and/or licensed to AxonIQ B.V.
+ *  under one or more contributor license agreements.
+ *
+ *  Licensed under the AxonIQ Open Source License Agreement v1.0;
+ *  you may not use this file except in compliance with the license.
+ *
+ */
 
-insert into function_roles (id, function, role) values (160, 'TRANSFORM', 'TRANSFORM');
-insert into function_roles (id, function, role) values (161, 'LIST_TRANSFORMATIONS', 'TRANSFORM');
-insert into function_roles (id, function, role)
-values (162, 'APPLY_TRANSFORMATION', 'TRANSFORM_ADMIN');
+insert into roles (role, description)
+values ('TRANSFORM', 'Transform events.');
+insert into roles (role, description)
+values ('TRANSFORM_ADMIN', 'Applies transformation.');
+
+insert into function_roles (function, role)
+values ('TRANSFORM', 'TRANSFORM');
+insert into function_roles (function, role)
+values ('LIST_TRANSFORMATIONS', 'TRANSFORM');
+insert into function_roles (function, role)
+values ('APPLY_TRANSFORMATION', 'TRANSFORM_ADMIN');
 
 insert into paths_to_functions (path, function)
 values ('io.axoniq.axonserver.grpc.event.EventTransformationService/Transformations', 'LIST_TRANSFORMATIONS');


### PR DESCRIPTION
Add a custom FlywayMigrationStrategy bean to repair before calling the migration. This fix prevents errors with the changed checksum of the flyway script when the updated script was already executed before. If the script failed in the previous runs, it is executed again.