### PR TITLE
Clean up EE and SE wording for 2023.1 release

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/StandardAxonServer.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/StandardAxonServer.java
@@ -33,12 +33,12 @@ import javax.annotation.PreDestroy;
 @EnableAsync
 @EnableScheduling
 @OpenAPIDefinition
-public class AxonServer {
-    private final Logger logger = LoggerFactory.getLogger(AxonServer.class);
+public class StandardAxonServer {
+    private final Logger logger = LoggerFactory.getLogger(StandardAxonServer.class);
 
     private final VersionInfoProvider versionInfoProvider;
 
-    public AxonServer(VersionInfoProvider versionInfoProvider) {
+    public StandardAxonServer(VersionInfoProvider versionInfoProvider) {
         this.versionInfoProvider = versionInfoProvider;
     }
 
@@ -54,7 +54,7 @@ public class AxonServer {
 
     public static void main(String[] args) {
         System.setProperty("spring.config.name", "axonserver");
-        SpringApplication.run(AxonServer.class, args);
+        SpringApplication.run(StandardAxonServer.class, args);
     }
 
     @PreDestroy

--- a/axonserver/src/main/resources/banner.txt
+++ b/axonserver/src/main/resources/banner.txt
@@ -3,6 +3,4 @@
    / _ \  \ \/ / _ \| '_ \\___ \ / _ \ '__\ \ / / _ \ '__|
   / ___ \  >  < (_) | | | |___) |  __/ |   \ V /  __/ |
  /_/   \_\/_/\_\___/|_| |_|____/ \___|_|    \_/ \___|_|
- Standard Edition                        Powered by AxonIQ
-
-version: @project.version@
+ @project.version@                        Powered by AxonIQ

--- a/axonserver/src/test/java/io/axoniq/axonserver/access/role/RoleControllerTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/access/role/RoleControllerTest.java
@@ -9,7 +9,7 @@
 
 package io.axoniq.axonserver.access.role;
 
-import io.axoniq.axonserver.AxonServer;
+import io.axoniq.axonserver.StandardAxonServer;
 import io.axoniq.axonserver.access.jpa.Role;
 import io.axoniq.axonserver.access.roles.RoleController;
 import io.axoniq.axonserver.access.roles.RoleRepository;
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.equalTo;
 @DataJpaTest
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 @ComponentScan(basePackages = "io.axoniq.axonserver.access", lazyInit = true)
-@ContextConfiguration(classes = AxonServer.class)
+@ContextConfiguration(classes = StandardAxonServer.class)
 public class RoleControllerTest {
 
     private RoleController roleController;

--- a/resources/json-logback.xml
+++ b/resources/json-logback.xml
@@ -18,7 +18,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <logger name="io.axoniq.axonserver.AxonServer" level="info" additivity="false">
+    <logger name="io.axoniq.axonserver.StandardAxonServer" level="info" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="io.axoniq.axonserver.grpc.Gateway" level="info" additivity="false">


### PR DESCRIPTION
Remove edition from banner, put version in focus
Main class is now AxonServer for Enterprise, and StandardAxonServer for Standard edition (for legacy reasons)
...