### PR TITLE
Do not open the index file in readonly mode when force-clean-mmap-index is specified

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexManager.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/localstorage/file/StandardIndexManager.java
@@ -788,16 +788,20 @@ public class StandardIndexManager implements IndexManager {
                 }
                 indexOpenMeter.mark();
                 logger.debug("{}: open {}", segment, properties.index(storagePath, segment));
+                boolean readOnly = true;
                 DBMaker.Maker maker = DBMaker.fileDB(properties.index(storagePath, segment))
-                                             .readOnly()
                                              .fileLockDisable();
                 if (properties.isUseMmapIndex() && segment.segment() > useMmapAfterIndex.get()) {
                     maker.fileMmapEnable();
                     if (properties.isForceCleanMmapIndex()) {
                         maker.cleanerHackEnable();
+                        readOnly = false;
                     }
                 } else {
                     maker.fileChannelEnable();
+                }
+                if (readOnly) {
+                    maker.readOnly();
                 }
                 this.db = maker.make();
                 this.positions = db.hashMap(AGGREGATE_MAP, Serializer.STRING, StandardIndexEntriesSerializer.get())


### PR DESCRIPTION
Using the readonly property creates a duplicate of the memory mapped file, which prevents the force-clean from working properly.