### PR TITLE
Fix command and query metrics after a client reconnects

### DIFF
--- a/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandMetricsRegistry.java
+++ b/axonserver/src/main/java/io/axoniq/axonserver/message/command/CommandMetricsRegistry.java
@@ -23,9 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
 
@@ -40,7 +38,6 @@ public class CommandMetricsRegistry {
 
     private final Logger logger = LoggerFactory.getLogger(CommandMetricsRegistry.class);
 
-    private final Map<String, Timer> timerMap = new ConcurrentHashMap<>();
     private final MeterFactory meterFactory;
 
     /**
@@ -58,13 +55,6 @@ public class CommandMetricsRegistry {
         meterFactory.remove(BaseMetricName.AXON_COMMAND, MeterFactory.TARGET, event.getClientId());
     }
 
-
-    private static String metricName(String command,
-                                     String sourceClientId,
-                                     String targetClientId,
-                                     String context) {
-        return String.join(".", command, sourceClientId, targetClientId, context);
-    }
 
     /**
      * Registers the duration of a command in the registry. Timer name is "axon.command", tags are the context,
@@ -92,17 +82,20 @@ public class CommandMetricsRegistry {
                         String sourceClientId,
                         String targetClientId,
                         String context) {
-        return timerMap.computeIfAbsent(metricName(command, sourceClientId, targetClientId, context),
-                                        n -> meterFactory.timer(BaseMetricName.AXON_COMMAND,
+        return meterFactory.timer(BaseMetricName.AXON_COMMAND,
                                                                 Tags.of(
                                                                         MeterFactory.REQUEST,
-                                                                        command.replaceAll("\\.", "/"),
+                                                                        normalizeCommandName(command),
                                                                         MeterFactory.CONTEXT,
                                                                         context,
                                                                         MeterFactory.SOURCE,
                                                                         sourceClientId,
                                                                         MeterFactory.TARGET,
-                                                                        targetClientId)));
+                                                                        targetClientId));
+    }
+
+    private String normalizeCommandName(String command) {
+        return command.replace(".", "/");
     }
 
 
@@ -112,7 +105,7 @@ public class CommandMetricsRegistry {
         Tags tags = Tags.of(MeterFactory.CONTEXT,
                             context,
                             MeterFactory.REQUEST,
-                            command.replaceAll("\\.", "/"),
+                            normalizeCommandName(command),
                             MeterFactory.TARGET,
                             targetClientId);
         return new CompositeMetric(meterFactory.snapshot(BaseMetricName.AXON_COMMAND, tags),

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandMetricsRegistryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/command/CommandMetricsRegistryTest.java
@@ -9,7 +9,7 @@
 
 package io.axoniq.axonserver.message.command;
 
-import io.axoniq.axonserver.message.ClientStreamIdentification;
+import io.axoniq.axonserver.applicationevents.TopologyEvents;
 import io.axoniq.axonserver.metric.DefaultMetricCollector;
 import io.axoniq.axonserver.metric.MeterFactory;
 import io.axoniq.axonserver.topology.Topology;
@@ -27,6 +27,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author Marc Gathier
  */
@@ -42,10 +44,17 @@ public class CommandMetricsRegistryTest {
 
     @Test
     public void add() {
-        ClientStreamIdentification client1 = new ClientStreamIdentification(Topology.DEFAULT_CONTEXT, "Client1");
-//        testSubject.add("Command", client1, 1);
-//
-//        assertEquals(1L, testSubject.commandMetric("Command", client1, null).getCount());
+        testSubject.add("Command", "source1", "target1", Topology.DEFAULT_CONTEXT, 1);
+        assertEquals(1L, testSubject.commandMetric("Command",  "target1",Topology.DEFAULT_CONTEXT, null).getCount());
+    }
+
+    @Test
+    public void addAfterReconnect() {
+        testSubject.add("Command", "source1", "target1", Topology.DEFAULT_CONTEXT, 1);
+        assertEquals(1L, testSubject.commandMetric("Command",  "target1",Topology.DEFAULT_CONTEXT, null).getCount());
+        testSubject.on(new TopologyEvents.ApplicationDisconnected(Topology.DEFAULT_CONTEXT, null, "source1", "disconnect" ));
+        testSubject.add("Command", "source1", "target1", Topology.DEFAULT_CONTEXT, 1);
+        assertEquals(1L, testSubject.commandMetric("Command",  "target1",Topology.DEFAULT_CONTEXT, null).getCount());
     }
 
 

--- a/axonserver/src/test/java/io/axoniq/axonserver/message/query/QueryMetricsRegistryTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/message/query/QueryMetricsRegistryTest.java
@@ -9,14 +9,19 @@
 
 package io.axoniq.axonserver.message.query;
 
+import io.axoniq.axonserver.applicationevents.TopologyEvents;
 import io.axoniq.axonserver.message.ClientStreamIdentification;
+import io.axoniq.axonserver.metric.BaseMetricName;
 import io.axoniq.axonserver.metric.DefaultMetricCollector;
 import io.axoniq.axonserver.metric.MeterFactory;
+import io.micrometer.core.instrument.search.Search;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
 import static io.axoniq.axonserver.topology.Topology.DEFAULT_CONTEXT;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marc Gathier
@@ -26,20 +31,45 @@ public class QueryMetricsRegistryTest {
     private QueryMetricsRegistry testSubject;
     private ClientStreamIdentification clientIdentification = new ClientStreamIdentification(DEFAULT_CONTEXT,
                                                                                              "processor");
+    private SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @Before
     public void setUp() {
-        testSubject = new QueryMetricsRegistry(new MeterFactory(new SimpleMeterRegistry(),
+        testSubject = new QueryMetricsRegistry(new MeterFactory(meterRegistry,
                                                                 new DefaultMetricCollector()));
     }
 
     @Test
     public void add() {
-        testSubject.addHandlerResponseTime(new QueryDefinition(DEFAULT_CONTEXT, "a"),
+        QueryDefinition queryDef = new QueryDefinition(DEFAULT_CONTEXT, "a");
+        testSubject.addHandlerResponseTime(queryDef,
                                            "source",
                                            "target",
                                            DEFAULT_CONTEXT,
                                            1L);
+        Search search = meterRegistry.find(BaseMetricName.AXON_QUERY.metric());
+        assertTrue(search.timers().stream().anyMatch(t -> "source".equals(t.getId().getTag(MeterFactory.SOURCE))));
+    }
+
+    @Test
+    public void addAfterDisconnect() {
+        QueryDefinition queryDef = new QueryDefinition(DEFAULT_CONTEXT, "a");
+        testSubject.addHandlerResponseTime(queryDef,
+                                           "source",
+                                           "target",
+                                           DEFAULT_CONTEXT,
+                                           1L);
+        testSubject.on( new TopologyEvents.ApplicationDisconnected(DEFAULT_CONTEXT, "component", "source", "disconnected"));
+        Search search = meterRegistry.find(BaseMetricName.AXON_QUERY.metric());
+        assertTrue(search.timers().stream().noneMatch(t -> "source".equals(t.getId().getTag(MeterFactory.SOURCE))));
+        assertTrue(search.timers().stream().noneMatch(t -> "source".equals(t.getId().getTag(MeterFactory.TARGET))));
+        testSubject.addHandlerResponseTime(queryDef,
+                                           "source",
+                                           "target",
+                                           DEFAULT_CONTEXT,
+                                           1L);
+        search = meterRegistry.find(BaseMetricName.AXON_QUERY.metric());
+        assertTrue(search.timers().stream().anyMatch(t -> "source".equals(t.getId().getTag(MeterFactory.SOURCE))));
     }
 
     @Test


### PR DESCRIPTION
Remove the timerMap as the timers don't need to be cached here.